### PR TITLE
feat: external centroids

### DIFF
--- a/src/algorithm/build.rs
+++ b/src/algorithm/build.rs
@@ -1,6 +1,6 @@
 use crate::algorithm::rabitq;
 use crate::algorithm::tuples::*;
-use crate::index::utils::load_centroids;
+use crate::index::utils::load_proj_vectors;
 use crate::postgres::BufferWriteGuard;
 use crate::postgres::Relation;
 use crate::types::ExternalCentroids;
@@ -37,31 +37,36 @@ pub fn build<T: HeapRelation, R: Reporter>(
     let dims = vector_options.dims;
     let is_residual =
         rabbithole_options.residual_quantization && vector_options.d == DistanceKind::L2;
-    let mut tuples_total = 0_usize;
-    let samples = {
-        let mut rand = rand::thread_rng();
-        let max_number_of_samples = rabbithole_options.nlist.saturating_mul(256);
-        let mut samples = Vec::new();
-        let mut number_of_samples = 0_u32;
-        heap_relation.traverse(|(_, vector)| {
-            pgrx::check_for_interrupts!();
-            assert_eq!(dims as usize, vector.len(), "invalid vector dimensions",);
-            let vector = rabitq::project(&vector);
-            if number_of_samples < max_number_of_samples {
-                samples.extend(vector);
-                number_of_samples += 1;
-            } else {
-                let index = rand.gen_range(0..max_number_of_samples) as usize;
-                let start = index * dims as usize;
-                let end = start + dims as usize;
-                samples[start..end].copy_from_slice(&vector);
-            }
-            tuples_total += 1;
-        });
-        Vec2::from_vec((number_of_samples as _, dims as _), samples)
+    let structure = match &rabbithole_options.external_centroids {
+        Some(_) => Structure::load(vector_options.clone(), rabbithole_options.clone()),
+        None => {
+            let mut tuples_total = 0_usize;
+            let samples = {
+                let mut rand = rand::thread_rng();
+                let max_number_of_samples = rabbithole_options.nlist.saturating_mul(256);
+                let mut samples = Vec::new();
+                let mut number_of_samples = 0_u32;
+                heap_relation.traverse(|(_, vector)| {
+                    pgrx::check_for_interrupts!();
+                    assert_eq!(dims as usize, vector.len(), "invalid vector dimensions",);
+                    let vector = rabitq::project(&vector);
+                    if number_of_samples < max_number_of_samples {
+                        samples.extend(vector);
+                        number_of_samples += 1;
+                    } else {
+                        let index = rand.gen_range(0..max_number_of_samples) as usize;
+                        let start = index * dims as usize;
+                        let end = start + dims as usize;
+                        samples[start..end].copy_from_slice(&vector);
+                    }
+                    tuples_total += 1;
+                });
+                Vec2::from_vec((number_of_samples as _, dims as _), samples)
+            };
+            reporter.tuples_total(tuples_total);
+            Structure::compute(vector_options.clone(), rabbithole_options.clone(), samples)
+        }
     };
-    reporter.tuples_total(tuples_total);
-    let structure = Structure::compute(vector_options.clone(), rabbithole_options.clone(), samples);
     let h2_len = structure.h2_len();
     let h1_len = structure.h1_len();
     let mut meta = Tape::create(&index_relation);
@@ -265,32 +270,27 @@ impl Structure {
         samples: Vec2<f32>,
     ) -> Self {
         let dims = vector_options.dims;
-        let h1_means = match &rabbithole_options.centroids {
-            Some(ExternalCentroids { table, column }) => {
-                load_centroids(table, column, rabbithole_options.nlist, vector_options.dims)
-            }
-            None => base::parallelism::RayonParallelism::scoped(
-                rabbithole_options.build_threads as _,
-                Arc::new(AtomicBool::new(false)),
-                |parallelism| {
-                    let raw = k_means::k_means(
-                        parallelism,
-                        rabbithole_options.nlist as usize,
-                        samples,
-                        rabbithole_options.spherical_centroids,
-                        10,
-                        false,
-                    );
-                    let mut centroids = Vec::new();
-                    for i in 0..rabbithole_options.nlist {
-                        centroids.push(raw[(i as usize,)].to_vec());
-                    }
-                    centroids
-                },
-            )
-            .expect("k_means panics")
-            .expect("k_means interrupted"),
-        };
+        let h1_means = base::parallelism::RayonParallelism::scoped(
+            rabbithole_options.build_threads as _,
+            Arc::new(AtomicBool::new(false)),
+            |parallelism| {
+                let raw = k_means::k_means(
+                    parallelism,
+                    rabbithole_options.nlist as usize,
+                    samples,
+                    rabbithole_options.spherical_centroids,
+                    10,
+                    false,
+                );
+                let mut centroids = Vec::new();
+                for i in 0..rabbithole_options.nlist {
+                    centroids.push(raw[(i as usize,)].to_vec());
+                }
+                centroids
+            },
+        )
+        .expect("k_means panics")
+        .expect("k_means interrupted");
         let h2_mean = {
             let mut centroid = vec![0.0; dims as _];
             for i in 0..rabbithole_options.nlist {
@@ -308,6 +308,68 @@ impl Structure {
             h2_children: (0..rabbithole_options.nlist).collect(),
             h1_means,
             h1_children: (0..rabbithole_options.nlist).map(|_| Vec::new()).collect(),
+        }
+    }
+    fn load(vector_options: VectorOptions, rabbithole_options: RabbitholeIndexingOptions) -> Self {
+        let dims = vector_options.dims;
+        let h1_means = match &rabbithole_options.external_centroids {
+            Some(ExternalCentroids {
+                table,
+                h1_means_column: h1,
+                ..
+            }) => load_proj_vectors(table, h1, rabbithole_options.nlist, vector_options.dims),
+            _ => unreachable!(),
+        };
+        let h1_children = match &rabbithole_options.external_centroids {
+            Some(ExternalCentroids {
+                table,
+                h1_children_column: Some(h1),
+                ..
+            }) => load_proj_vectors(table, h1, 1, vector_options.dims)
+                .into_iter()
+                .map(|v| v.into_iter().map(|f| f as u32).collect())
+                .collect(),
+            _ => (0..rabbithole_options.nlist).map(|_| Vec::new()).collect(),
+        };
+        let h2_mean = match &rabbithole_options.external_centroids {
+            Some(ExternalCentroids {
+                table,
+                h2_mean_column: Some(h2),
+                ..
+            }) => load_proj_vectors(table, h2, 1, vector_options.dims)
+                .pop()
+                .expect("load h2_mean panic"),
+            _ => {
+                let mut centroid = vec![0.0; dims as _];
+                for i in 0..rabbithole_options.nlist {
+                    for j in 0..dims {
+                        centroid[j as usize] += h1_means[i as usize][j as usize];
+                    }
+                }
+                for j in 0..dims {
+                    centroid[j as usize] /= rabbithole_options.nlist as f32;
+                }
+                centroid
+            }
+        };
+        let h2_children = match &rabbithole_options.external_centroids {
+            Some(ExternalCentroids {
+                table,
+                h2_children_column: Some(h2),
+                ..
+            }) => load_proj_vectors(table, h2, 1, vector_options.dims)
+                .pop()
+                .expect("load h2_children panic")
+                .into_iter()
+                .map(|f| f as u32)
+                .collect(),
+            _ => (0..rabbithole_options.nlist).collect(),
+        };
+        Structure {
+            h2_mean,
+            h2_children,
+            h1_means,
+            h1_children,
         }
     }
     fn h2_len(&self) -> u32 {

--- a/src/index/utils.rs
+++ b/src/index/utils.rs
@@ -4,7 +4,7 @@ use pgrx::pg_sys::panic::ErrorReportable;
 use pgrx::{error, Spi};
 
 use crate::algorithm::rabitq;
-use crate::datatype::memory_vecf32::Vecf32Output;
+use crate::datatype::memory_pgvector_vector::PgvectorVectorOutput;
 
 pub fn pointer_to_ctid(pointer: Pointer) -> pgrx::pg_sys::ItemPointerData {
     let value = pointer.as_u64();
@@ -25,23 +25,23 @@ pub fn ctid_to_pointer(ctid: pgrx::pg_sys::ItemPointerData) -> Pointer {
     Pointer::new(value)
 }
 
-pub fn load_centroids(table_name: &str, column_name: &str, nlist: u32, dims: u32) -> Vec<Vec<f32>> {
+pub fn load_proj_vectors(table_name: &str, column_name: &str, rows: u32, dims: u32) -> Vec<Vec<f32>> {
     let query = format!("SELECT {column_name} FROM {table_name};");
     let mut centroids = Vec::new();
 
     Spi::connect(|client| {
         let tup_table = client.select(&query, None, None).unwrap_or_report();
-        assert_eq!(tup_table.len(), nlist as usize);
+        assert_eq!(tup_table.len(), rows as usize);
 
         for row in tup_table {
-            let vector = row[column_name].value::<Vecf32Output>();
+            let vector = row[column_name].value::<PgvectorVectorOutput>();
             if let Ok(Some(v)) = vector {
                 let borrowed = v.as_borrowed();
                 assert_eq!(borrowed.dims(), dims);
                 let projected_centroids = rabitq::project(borrowed.slice());
                 centroids.push(projected_centroids);
             } else {
-                error!("centroid vectors is not valid")
+                error!("load vectors from column is not valid")
             }
         }
         centroids

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,7 +5,10 @@ use validator::Validate;
 #[serde(deny_unknown_fields)]
 pub struct ExternalCentroids {
     pub table: String,
-    pub column: String,
+    pub h1_means_column: String,
+    pub h1_children_column: Option<String>,
+    pub h2_mean_column: Option<String>,
+    pub h2_children_column: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Validate)]
@@ -21,7 +24,7 @@ pub struct RabbitholeIndexingOptions {
     #[serde(default = "RabbitholeIndexingOptions::default_build_threads")]
     #[validate(range(min = 1, max = 255))]
     pub build_threads: u16,
-    pub centroids: Option<ExternalCentroids>,
+    pub external_centroids: Option<ExternalCentroids>,
 }
 
 impl RabbitholeIndexingOptions {
@@ -46,7 +49,7 @@ impl Default for RabbitholeIndexingOptions {
             spherical_centroids: Self::default_spherical_centroids(),
             residual_quantization: Self::default_residual_quantization(),
             build_threads: Self::default_build_threads(),
-            centroids: None,
+            external_centroids: None,
         }
     }
 }


### PR DESCRIPTION
⚠️There is a sharp decline of QPS from branch `ivf-rabitq-fast-scan-centroids-mean-projection` to `main`.

We build 3 images:
- `starkind/rabbithole:pg16-old-centroids` based on branch `ext-centroids`(from `ivf-rabitq-fast-scan-centroids-mean-projection`) 
- `starkind/rabbithole:pg16-v0.0.0` based on current branch `feat/ext-centroids`(from `main`)
- `starkind/rabbithole:pg16-main` based on branch `main`

## Main branch QPS
`starkind/rabbithole:pg16-v0.0.0` and `starkind/rabbithole:pg16-main` share the bench result of:

sift Top 10 QPS:**20.54** Recall:0.9988

## Old branch QPS
`starkind/rabbithole:pg16-old-centroids` has the bench result of:

sift Top 10 QPS:**296.14** Recall: 0.9940

## Test Script
The bench script can be found at https://github.com/tensorchord/rabbithole/tree/ext-centroids/bench
