### PR TITLE
fix: return Oid::INVALID to skip binary-coercible test

### DIFF
--- a/src/datatype/memory_pgvector_vector.rs
+++ b/src/datatype/memory_pgvector_vector.rs
@@ -141,7 +141,7 @@ impl IntoDatum for PgvectorVectorOutput {
     }
 
     fn type_oid() -> Oid {
-        panic!("calling `type_oid` is never expected")
+        Oid::INVALID
     }
 
     fn is_compatible_with(_: Oid) -> bool {


### PR DESCRIPTION
closes #52