### PR TITLE
refactor: remove meaningless target feature requirements

### DIFF
--- a/crates/simd/build.rs
+++ b/crates/simd/build.rs
@@ -8,5 +8,5 @@ fn main() {
         .flag("-ffp-contract=fast")
         .flag("-freciprocal-math")
         .flag("-fno-signed-zeros")
-        .compile("base_cshim");
+        .compile("simd_cshim");
 }

--- a/crates/simd/src/bit.rs
+++ b/crates/simd/src/bit.rs
@@ -8,9 +8,9 @@ mod sum_of_and {
 
     #[inline]
     #[cfg(target_arch = "x86_64")]
-    #[crate::target_cpu(enable = "v4")]
+    #[crate::target_cpu(enable = "v4.512")]
     #[target_feature(enable = "avx512vpopcntdq")]
-    fn sum_of_and_v4_avx512vpopcntdq(lhs: &[u64], rhs: &[u64]) -> u32 {
+    fn sum_of_and_v4_512_avx512vpopcntdq(lhs: &[u64], rhs: &[u64]) -> u32 {
         assert!(lhs.len() == rhs.len());
         unsafe {
             use std::arch::x86_64::*;
@@ -38,21 +38,24 @@ mod sum_of_and {
 
     #[cfg(all(target_arch = "x86_64", test, not(miri)))]
     #[test]
-    fn sum_of_and_v4_avx512vpopcntdq_test() {
-        if !crate::is_cpu_detected!("v4") || !crate::is_feature_detected!("avx512vpopcntdq") {
-            println!("test {} ... skipped (v4:avx512vpopcntdq)", module_path!());
+    fn sum_of_and_v4_512_avx512vpopcntdq_test() {
+        if !crate::is_cpu_detected!("v4.512") || !crate::is_feature_detected!("avx512vpopcntdq") {
+            println!(
+                "test {} ... skipped (v4.512:avx512vpopcntdq)",
+                module_path!()
+            );
             return;
         }
         for _ in 0..if cfg!(not(miri)) { 256 } else { 1 } {
             let lhs = (0..126).map(|_| rand::random::<u64>()).collect::<Vec<_>>();
             let rhs = (0..126).map(|_| rand::random::<u64>()).collect::<Vec<_>>();
-            let specialized = unsafe { sum_of_and_v4_avx512vpopcntdq(&lhs, &rhs) };
-            let fallback = sum_of_and_fallback(&lhs, &rhs);
+            let specialized = unsafe { sum_of_and_v4_512_avx512vpopcntdq(&lhs, &rhs) };
+            let fallback = fallback(&lhs, &rhs);
             assert_eq!(specialized, fallback);
         }
     }
 
-    #[crate::multiversion(@"v4:avx512vpopcntdq", "v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion(@"v4.512:avx512vpopcntdq", "v4.512", "v3", "v2", "a2")]
     pub fn sum_of_and(lhs: &[u64], rhs: &[u64]) -> u32 {
         assert_eq!(lhs.len(), rhs.len());
         let n = lhs.len();
@@ -74,9 +77,9 @@ mod sum_of_or {
 
     #[inline]
     #[cfg(target_arch = "x86_64")]
-    #[crate::target_cpu(enable = "v4")]
+    #[crate::target_cpu(enable = "v4.512")]
     #[target_feature(enable = "avx512vpopcntdq")]
-    fn sum_of_or_v4_avx512vpopcntdq(lhs: &[u64], rhs: &[u64]) -> u32 {
+    fn sum_of_or_v4_512_avx512vpopcntdq(lhs: &[u64], rhs: &[u64]) -> u32 {
         assert!(lhs.len() == rhs.len());
         unsafe {
             use std::arch::x86_64::*;
@@ -104,21 +107,24 @@ mod sum_of_or {
 
     #[cfg(all(target_arch = "x86_64", test, not(miri)))]
     #[test]
-    fn sum_of_or_v4_avx512vpopcntdq_test() {
-        if !crate::is_cpu_detected!("v4") || !crate::is_feature_detected!("avx512vpopcntdq") {
-            println!("test {} ... skipped (v4:avx512vpopcntdq)", module_path!());
+    fn sum_of_or_v4_512_avx512vpopcntdq_test() {
+        if !crate::is_cpu_detected!("v4.512") || !crate::is_feature_detected!("avx512vpopcntdq") {
+            println!(
+                "test {} ... skipped (v4.512:avx512vpopcntdq)",
+                module_path!()
+            );
             return;
         }
         for _ in 0..if cfg!(not(miri)) { 256 } else { 1 } {
             let lhs = (0..126).map(|_| rand::random::<u64>()).collect::<Vec<_>>();
             let rhs = (0..126).map(|_| rand::random::<u64>()).collect::<Vec<_>>();
-            let specialized = unsafe { sum_of_or_v4_avx512vpopcntdq(&lhs, &rhs) };
-            let fallback = sum_of_or_fallback(&lhs, &rhs);
+            let specialized = unsafe { sum_of_or_v4_512_avx512vpopcntdq(&lhs, &rhs) };
+            let fallback = fallback(&lhs, &rhs);
             assert_eq!(specialized, fallback);
         }
     }
 
-    #[crate::multiversion(@"v4:avx512vpopcntdq", "v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion(@"v4.512:avx512vpopcntdq", "v4.512", "v3", "v2", "a2")]
     pub fn sum_of_or(lhs: &[u64], rhs: &[u64]) -> u32 {
         assert_eq!(lhs.len(), rhs.len());
         let n = lhs.len();
@@ -140,9 +146,9 @@ mod sum_of_xor {
 
     #[inline]
     #[cfg(target_arch = "x86_64")]
-    #[crate::target_cpu(enable = "v4")]
+    #[crate::target_cpu(enable = "v4.512")]
     #[target_feature(enable = "avx512vpopcntdq")]
-    fn sum_of_xor_v4_avx512vpopcntdq(lhs: &[u64], rhs: &[u64]) -> u32 {
+    fn sum_of_xor_v4_512_avx512vpopcntdq(lhs: &[u64], rhs: &[u64]) -> u32 {
         assert!(lhs.len() == rhs.len());
         unsafe {
             use std::arch::x86_64::*;
@@ -170,21 +176,24 @@ mod sum_of_xor {
 
     #[cfg(all(target_arch = "x86_64", test, not(miri)))]
     #[test]
-    fn sum_of_xor_v4_avx512vpopcntdq_test() {
-        if !crate::is_cpu_detected!("v4") || !crate::is_feature_detected!("avx512vpopcntdq") {
-            println!("test {} ... skipped (v4:avx512vpopcntdq)", module_path!());
+    fn sum_of_xor_v4_512_avx512vpopcntdq_test() {
+        if !crate::is_cpu_detected!("v4.512") || !crate::is_feature_detected!("avx512vpopcntdq") {
+            println!(
+                "test {} ... skipped (v4.512:avx512vpopcntdq)",
+                module_path!()
+            );
             return;
         }
         for _ in 0..if cfg!(not(miri)) { 256 } else { 1 } {
             let lhs = (0..126).map(|_| rand::random::<u64>()).collect::<Vec<_>>();
             let rhs = (0..126).map(|_| rand::random::<u64>()).collect::<Vec<_>>();
-            let specialized = unsafe { sum_of_xor_v4_avx512vpopcntdq(&lhs, &rhs) };
-            let fallback = sum_of_xor_fallback(&lhs, &rhs);
+            let specialized = unsafe { sum_of_xor_v4_512_avx512vpopcntdq(&lhs, &rhs) };
+            let fallback = fallback(&lhs, &rhs);
             assert_eq!(specialized, fallback);
         }
     }
 
-    #[crate::multiversion(@"v4:avx512vpopcntdq", "v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion(@"v4.512:avx512vpopcntdq", "v4.512", "v3", "v2", "a2")]
     pub fn sum_of_xor(lhs: &[u64], rhs: &[u64]) -> u32 {
         assert_eq!(lhs.len(), rhs.len());
         let n = lhs.len();
@@ -206,9 +215,9 @@ mod sum_of_and_or {
 
     #[inline]
     #[cfg(target_arch = "x86_64")]
-    #[crate::target_cpu(enable = "v4")]
+    #[crate::target_cpu(enable = "v4.512")]
     #[target_feature(enable = "avx512vpopcntdq")]
-    fn sum_of_and_or_v4_avx512vpopcntdq(lhs: &[u64], rhs: &[u64]) -> (u32, u32) {
+    fn sum_of_and_or_v4_512_avx512vpopcntdq(lhs: &[u64], rhs: &[u64]) -> (u32, u32) {
         assert!(lhs.len() == rhs.len());
         unsafe {
             use std::arch::x86_64::*;
@@ -242,21 +251,24 @@ mod sum_of_and_or {
 
     #[cfg(all(target_arch = "x86_64", test, not(miri)))]
     #[test]
-    fn sum_of_xor_v4_avx512vpopcntdq_test() {
-        if !crate::is_cpu_detected!("v4") || !crate::is_feature_detected!("avx512vpopcntdq") {
-            println!("test {} ... skipped (v4:avx512vpopcntdq)", module_path!());
+    fn sum_of_xor_v4_512_avx512vpopcntdq_test() {
+        if !crate::is_cpu_detected!("v4.512") || !crate::is_feature_detected!("avx512vpopcntdq") {
+            println!(
+                "test {} ... skipped (v4.512:avx512vpopcntdq)",
+                module_path!()
+            );
             return;
         }
         for _ in 0..if cfg!(not(miri)) { 256 } else { 1 } {
             let lhs = (0..126).map(|_| rand::random::<u64>()).collect::<Vec<_>>();
             let rhs = (0..126).map(|_| rand::random::<u64>()).collect::<Vec<_>>();
-            let specialized = unsafe { sum_of_and_or_v4_avx512vpopcntdq(&lhs, &rhs) };
-            let fallback = sum_of_and_or_fallback(&lhs, &rhs);
+            let specialized = unsafe { sum_of_and_or_v4_512_avx512vpopcntdq(&lhs, &rhs) };
+            let fallback = fallback(&lhs, &rhs);
             assert_eq!(specialized, fallback);
         }
     }
 
-    #[crate::multiversion(@"v4:avx512vpopcntdq", "v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion(@"v4.512:avx512vpopcntdq", "v4.512", "v3", "v2", "a2")]
     pub fn sum_of_and_or(lhs: &[u64], rhs: &[u64]) -> (u32, u32) {
         assert_eq!(lhs.len(), rhs.len());
         let n = lhs.len();
@@ -280,9 +292,9 @@ mod sum_of_x {
 
     #[inline]
     #[cfg(target_arch = "x86_64")]
-    #[crate::target_cpu(enable = "v4")]
+    #[crate::target_cpu(enable = "v4.512")]
     #[target_feature(enable = "avx512vpopcntdq")]
-    fn sum_of_x_v4_avx512vpopcntdq(this: &[u64]) -> u32 {
+    fn sum_of_x_v4_512_avx512vpopcntdq(this: &[u64]) -> u32 {
         unsafe {
             use std::arch::x86_64::*;
             let mut and = _mm512_setzero_si512();
@@ -305,20 +317,23 @@ mod sum_of_x {
 
     #[cfg(all(target_arch = "x86_64", test, not(miri)))]
     #[test]
-    fn sum_of_x_v4_avx512vpopcntdq_test() {
-        if !crate::is_cpu_detected!("v4") || !crate::is_feature_detected!("avx512vpopcntdq") {
-            println!("test {} ... skipped (v4:avx512vpopcntdq)", module_path!());
+    fn sum_of_x_v4_512_avx512vpopcntdq_test() {
+        if !crate::is_cpu_detected!("v4.512") || !crate::is_feature_detected!("avx512vpopcntdq") {
+            println!(
+                "test {} ... skipped (v4.512:avx512vpopcntdq)",
+                module_path!()
+            );
             return;
         }
         for _ in 0..if cfg!(not(miri)) { 256 } else { 1 } {
             let this = (0..126).map(|_| rand::random::<u64>()).collect::<Vec<_>>();
-            let specialized = unsafe { sum_of_x_v4_avx512vpopcntdq(&this) };
-            let fallback = sum_of_x_fallback(&this);
+            let specialized = unsafe { sum_of_x_v4_512_avx512vpopcntdq(&this) };
+            let fallback = fallback(&this);
             assert_eq!(specialized, fallback);
         }
     }
 
-    #[crate::multiversion(@"v4:avx512vpopcntdq", "v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion(@"v4.512:avx512vpopcntdq", "v4.512", "v3", "v2", "a2")]
     pub fn sum_of_x(this: &[u64]) -> u32 {
         let n = this.len();
         let mut and = 0;
@@ -335,7 +350,7 @@ pub fn vector_and(lhs: &[u64], rhs: &[u64]) -> Vec<u64> {
 }
 
 mod vector_and {
-    #[crate::multiversion("v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion("v4.512", "v3", "v2", "a2")]
     pub fn vector_and(lhs: &[u64], rhs: &[u64]) -> Vec<u64> {
         assert_eq!(lhs.len(), rhs.len());
         let n = lhs.len();
@@ -358,7 +373,7 @@ pub fn vector_or(lhs: &[u64], rhs: &[u64]) -> Vec<u64> {
 }
 
 mod vector_or {
-    #[crate::multiversion("v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion("v4.512", "v3", "v2", "a2")]
     pub fn vector_or(lhs: &[u64], rhs: &[u64]) -> Vec<u64> {
         assert_eq!(lhs.len(), rhs.len());
         let n = lhs.len();
@@ -381,7 +396,7 @@ pub fn vector_xor(lhs: &[u64], rhs: &[u64]) -> Vec<u64> {
 }
 
 mod vector_xor {
-    #[crate::multiversion("v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion("v4.512", "v3", "v2", "a2")]
     pub fn vector_xor(lhs: &[u64], rhs: &[u64]) -> Vec<u64> {
         assert_eq!(lhs.len(), rhs.len());
         let n = lhs.len();

--- a/crates/simd/src/emulate.rs
+++ b/crates/simd/src/emulate.rs
@@ -3,7 +3,7 @@
 // Instructions. arXiv preprint arXiv:2112.06342.
 #[inline]
 #[cfg(target_arch = "x86_64")]
-#[crate::target_cpu(enable = "v4")]
+#[crate::target_cpu(enable = "v4.512")]
 pub fn emulate_mm512_2intersect_epi32(
     a: std::arch::x86_64::__m512i,
     b: std::arch::x86_64::__m512i,
@@ -85,7 +85,7 @@ pub fn emulate_mm_reduce_add_ps(mut x: std::arch::x86_64::__m128) -> f32 {
 
 #[inline]
 #[cfg(target_arch = "x86_64")]
-#[crate::target_cpu(enable = "v4")]
+#[crate::target_cpu(enable = "v4.512")]
 pub fn emulate_mm512_reduce_add_epi16(x: std::arch::x86_64::__m512i) -> i16 {
     unsafe {
         use std::arch::x86_64::*;

--- a/crates/simd/src/f16.rs
+++ b/crates/simd/src/f16.rs
@@ -131,7 +131,7 @@ impl Floating for f16 {
 mod reduce_or_of_is_zero_x {
     use half::f16;
 
-    #[crate::multiversion("v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion("v4.512", "v3", "v2", "a2")]
     pub fn reduce_or_of_is_zero_x(this: &[f16]) -> bool {
         for &x in this {
             if x == f16::ZERO {
@@ -147,7 +147,7 @@ mod reduce_sum_of_x {
 
     use half::f16;
 
-    #[crate::multiversion("v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion("v4.512", "v3", "v2", "a2")]
     pub fn reduce_sum_of_x(this: &[f16]) -> f32 {
         let n = this.len();
         let mut x = 0.0f32;
@@ -163,7 +163,7 @@ mod reduce_sum_of_abs_x {
 
     use half::f16;
 
-    #[crate::multiversion("v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion("v4.512", "v3", "v2", "a2")]
     pub fn reduce_sum_of_abs_x(this: &[f16]) -> f32 {
         let n = this.len();
         let mut x = 0.0f32;
@@ -179,7 +179,7 @@ mod reduce_sum_of_x2 {
 
     use half::f16;
 
-    #[crate::multiversion("v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion("v4.512", "v3", "v2", "a2")]
     pub fn reduce_sum_of_x2(this: &[f16]) -> f32 {
         let n = this.len();
         let mut x2 = 0.0f32;
@@ -195,7 +195,7 @@ mod reduce_min_max_of_x {
 
     use half::f16;
 
-    #[crate::multiversion("v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion("v4.512", "v3", "v2", "a2")]
     pub fn reduce_min_max_of_x(this: &[f16]) -> (f32, f32) {
         let mut min = f32::INFINITY;
         let mut max = f32::NEG_INFINITY;
@@ -213,9 +213,9 @@ mod reduce_sum_of_xy {
 
     #[inline]
     #[cfg(target_arch = "x86_64")]
-    #[crate::target_cpu(enable = "v4")]
+    #[crate::target_cpu(enable = "v4.512")]
     #[target_feature(enable = "avx512fp16")]
-    pub fn reduce_sum_of_xy_v4_avx512fp16(lhs: &[f16], rhs: &[f16]) -> f32 {
+    pub fn reduce_sum_of_xy_v4_512_avx512fp16(lhs: &[f16], rhs: &[f16]) -> f32 {
         assert!(lhs.len() == rhs.len());
         unsafe {
             use std::arch::x86_64::*;
@@ -243,11 +243,11 @@ mod reduce_sum_of_xy {
 
     #[cfg(all(target_arch = "x86_64", test, not(miri)))]
     #[test]
-    fn reduce_sum_of_xy_v4_avx512fp16_test() {
+    fn reduce_sum_of_xy_v4_512_avx512fp16_test() {
         use rand::Rng;
         const EPSILON: f32 = 2.0;
-        if !crate::is_cpu_detected!("v4") || !crate::is_feature_detected!("avx512fp16") {
-            println!("test {} ... skipped (v4:avx512fp16)", module_path!());
+        if !crate::is_cpu_detected!("v4.512") || !crate::is_feature_detected!("avx512fp16") {
+            println!("test {} ... skipped (v4_512:avx512fp16)", module_path!());
             return;
         }
         let mut rng = rand::rng();
@@ -262,8 +262,8 @@ mod reduce_sum_of_xy {
             for z in 3984..4016 {
                 let lhs = &lhs[..z];
                 let rhs = &rhs[..z];
-                let specialized = unsafe { reduce_sum_of_xy_v4_avx512fp16(lhs, rhs) };
-                let fallback = reduce_sum_of_xy_fallback(lhs, rhs);
+                let specialized = unsafe { reduce_sum_of_xy_v4_512_avx512fp16(lhs, rhs) };
+                let fallback = fallback(lhs, rhs);
                 assert!(
                     (specialized - fallback).abs() < EPSILON,
                     "specialized = {specialized}, fallback = {fallback}."
@@ -274,8 +274,8 @@ mod reduce_sum_of_xy {
 
     #[inline]
     #[cfg(target_arch = "x86_64")]
-    #[crate::target_cpu(enable = "v4")]
-    pub fn reduce_sum_of_xy_v4(lhs: &[f16], rhs: &[f16]) -> f32 {
+    #[crate::target_cpu(enable = "v4.512")]
+    pub fn reduce_sum_of_xy_v4_512(lhs: &[f16], rhs: &[f16]) -> f32 {
         assert!(lhs.len() == rhs.len());
         unsafe {
             use std::arch::x86_64::*;
@@ -306,7 +306,7 @@ mod reduce_sum_of_xy {
     fn reduce_sum_of_xy_v4_test() {
         use rand::Rng;
         const EPSILON: f32 = 2.0;
-        if !crate::is_cpu_detected!("v4") {
+        if !crate::is_cpu_detected!("v4.512") {
             println!("test {} ... skipped (v4)", module_path!());
             return;
         }
@@ -319,8 +319,8 @@ mod reduce_sum_of_xy {
             let rhs = (0..n)
                 .map(|_| f16::from_f32(rng.random_range(-1.0..=1.0)))
                 .collect::<Vec<_>>();
-            let specialized = unsafe { reduce_sum_of_xy_v4(&lhs, &rhs) };
-            let fallback = reduce_sum_of_xy_fallback(&lhs, &rhs);
+            let specialized = unsafe { reduce_sum_of_xy_v4_512(&lhs, &rhs) };
+            let fallback = fallback(&lhs, &rhs);
             assert!(
                 (specialized - fallback).abs() < EPSILON,
                 "specialized = {specialized}, fallback = {fallback}."
@@ -383,76 +383,7 @@ mod reduce_sum_of_xy {
                 let lhs = &lhs[..z];
                 let rhs = &rhs[..z];
                 let specialized = unsafe { reduce_sum_of_xy_v3(lhs, rhs) };
-                let fallback = reduce_sum_of_xy_fallback(lhs, rhs);
-                assert!(
-                    (specialized - fallback).abs() < EPSILON,
-                    "specialized = {specialized}, fallback = {fallback}."
-                );
-            }
-        }
-    }
-
-    #[inline]
-    #[cfg(target_arch = "x86_64")]
-    #[crate::target_cpu(enable = "v2")]
-    #[target_feature(enable = "f16c")]
-    #[target_feature(enable = "fma")]
-    pub fn reduce_sum_of_xy_v2_f16c_fma(lhs: &[f16], rhs: &[f16]) -> f32 {
-        use crate::emulate::emulate_mm_reduce_add_ps;
-        assert!(lhs.len() == rhs.len());
-        unsafe {
-            use std::arch::x86_64::*;
-            let mut n = lhs.len();
-            let mut a = lhs.as_ptr();
-            let mut b = rhs.as_ptr();
-            let mut xy = _mm_setzero_ps();
-            while n >= 4 {
-                let x = _mm_cvtph_ps(_mm_loadu_si128(a.cast()));
-                let y = _mm_cvtph_ps(_mm_loadu_si128(b.cast()));
-                a = a.add(4);
-                b = b.add(4);
-                n -= 4;
-                xy = _mm_fmadd_ps(x, y, xy);
-            }
-            let mut xy = emulate_mm_reduce_add_ps(xy);
-            while n > 0 {
-                let x = a.read().to_f32();
-                let y = b.read().to_f32();
-                a = a.add(1);
-                b = b.add(1);
-                n -= 1;
-                xy += x * y;
-            }
-            xy
-        }
-    }
-
-    #[cfg(all(target_arch = "x86_64", test, not(miri)))]
-    #[test]
-    fn reduce_sum_of_xy_v2_f16c_fma_test() {
-        use rand::Rng;
-        const EPSILON: f32 = 2.0;
-        if !crate::is_cpu_detected!("v2")
-            || !crate::is_feature_detected!("f16c")
-            || !crate::is_feature_detected!("fma")
-        {
-            println!("test {} ... skipped (v2:f16c:fma)", module_path!());
-            return;
-        }
-        let mut rng = rand::rng();
-        for _ in 0..if cfg!(not(miri)) { 256 } else { 1 } {
-            let n = 4016;
-            let lhs = (0..n)
-                .map(|_| f16::from_f32(rng.random_range(-1.0..=1.0)))
-                .collect::<Vec<_>>();
-            let rhs = (0..n)
-                .map(|_| f16::from_f32(rng.random_range(-1.0..=1.0)))
-                .collect::<Vec<_>>();
-            for z in 3984..4016 {
-                let lhs = &lhs[..z];
-                let rhs = &rhs[..z];
-                let specialized = unsafe { reduce_sum_of_xy_v2_f16c_fma(lhs, rhs) };
-                let fallback = reduce_sum_of_xy_fallback(lhs, rhs);
+                let fallback = fallback(lhs, rhs);
                 assert!(
                     (specialized - fallback).abs() < EPSILON,
                     "specialized = {specialized}, fallback = {fallback}."
@@ -463,33 +394,25 @@ mod reduce_sum_of_xy {
 
     #[inline]
     #[cfg(target_arch = "aarch64")]
-    #[crate::target_cpu(enable = "v8.3a")]
+    #[crate::target_cpu(enable = "a2")]
     #[target_feature(enable = "fp16")]
-    pub fn reduce_sum_of_xy_v8_3a_fp16(lhs: &[f16], rhs: &[f16]) -> f32 {
+    pub fn reduce_sum_of_xy_a2_fp16(lhs: &[f16], rhs: &[f16]) -> f32 {
         assert!(lhs.len() == rhs.len());
         unsafe {
             extern "C" {
-                fn fp16_reduce_sum_of_xy_v8_3a_fp16_unroll(
-                    a: *const (),
-                    b: *const (),
-                    n: usize,
-                ) -> f32;
+                fn fp16_reduce_sum_of_xy_a2_fp16(a: *const (), b: *const (), n: usize) -> f32;
             }
-            fp16_reduce_sum_of_xy_v8_3a_fp16_unroll(
-                lhs.as_ptr().cast(),
-                rhs.as_ptr().cast(),
-                lhs.len(),
-            )
+            fp16_reduce_sum_of_xy_a2_fp16(lhs.as_ptr().cast(), rhs.as_ptr().cast(), lhs.len())
         }
     }
 
     #[cfg(all(target_arch = "aarch64", test, not(miri)))]
     #[test]
-    fn reduce_sum_of_xy_v8_3a_fp16_test() {
+    fn reduce_sum_of_xy_a2_fp16_test() {
         use rand::Rng;
         const EPSILON: f32 = 2.0;
-        if !crate::is_cpu_detected!("v8.3a") || !crate::is_feature_detected!("fp16") {
-            println!("test {} ... skipped (v8.3a:fp16)", module_path!());
+        if !crate::is_cpu_detected!("a2") || !crate::is_feature_detected!("fp16") {
+            println!("test {} ... skipped (a2:fp16)", module_path!());
             return;
         }
         let mut rng = rand::rng();
@@ -504,8 +427,8 @@ mod reduce_sum_of_xy {
             for z in 3984..4016 {
                 let lhs = &lhs[..z];
                 let rhs = &rhs[..z];
-                let specialized = unsafe { reduce_sum_of_xy_v8_3a_fp16(lhs, rhs) };
-                let fallback = reduce_sum_of_xy_fallback(lhs, rhs);
+                let specialized = unsafe { reduce_sum_of_xy_a2_fp16(lhs, rhs) };
+                let fallback = fallback(lhs, rhs);
                 assert!(
                     (specialized - fallback).abs() < EPSILON,
                     "specialized = {specialized}, fallback = {fallback}."
@@ -514,30 +437,27 @@ mod reduce_sum_of_xy {
         }
     }
 
-    // temporarily disables this for uncertain precision
-    #[cfg_attr(not(test), expect(dead_code))]
     #[inline]
     #[cfg(target_arch = "aarch64")]
-    #[crate::target_cpu(enable = "v8.3a")]
+    #[crate::target_cpu(enable = "a2")]
     #[target_feature(enable = "sve")]
-    pub fn reduce_sum_of_xy_v8_3a_sve(lhs: &[f16], rhs: &[f16]) -> f32 {
+    pub fn reduce_sum_of_xy_a3_512(lhs: &[f16], rhs: &[f16]) -> f32 {
         assert!(lhs.len() == rhs.len());
         unsafe {
             extern "C" {
-                fn fp16_reduce_sum_of_xy_v8_3a_sve(a: *const (), b: *const (), n: usize) -> f32;
+                fn fp16_reduce_sum_of_xy_a3_512(a: *const (), b: *const (), n: usize) -> f32;
             }
-            fp16_reduce_sum_of_xy_v8_3a_sve(lhs.as_ptr().cast(), rhs.as_ptr().cast(), lhs.len())
+            fp16_reduce_sum_of_xy_a3_512(lhs.as_ptr().cast(), rhs.as_ptr().cast(), lhs.len())
         }
     }
 
     #[cfg(all(target_arch = "aarch64", test, not(miri)))]
     #[test]
-    #[ignore]
-    fn reduce_sum_of_xy_v8_3a_sve_test() {
+    fn reduce_sum_of_xy_a3_512_test() {
         use rand::Rng;
         const EPSILON: f32 = 2.0;
-        if !crate::is_cpu_detected!("v8.3a") || !crate::is_feature_detected!("sve") {
-            println!("test {} ... skipped (v8.3a:sve)", module_path!());
+        if !crate::is_cpu_detected!("a3.512") {
+            println!("test {} ... skipped (a3.512)", module_path!());
             return;
         }
         let mut rng = rand::rng();
@@ -552,8 +472,8 @@ mod reduce_sum_of_xy {
             for z in 3984..4016 {
                 let lhs = &lhs[..z];
                 let rhs = &rhs[..z];
-                let specialized = unsafe { reduce_sum_of_xy_v8_3a_sve(lhs, rhs) };
-                let fallback = reduce_sum_of_xy_fallback(lhs, rhs);
+                let specialized = unsafe { reduce_sum_of_xy_a3_512(lhs, rhs) };
+                let fallback = fallback(lhs, rhs);
                 assert!(
                     (specialized - fallback).abs() < EPSILON,
                     "specialized = {specialized}, fallback = {fallback}."
@@ -562,7 +482,7 @@ mod reduce_sum_of_xy {
         }
     }
 
-    #[crate::multiversion(@"v4:avx512fp16", @"v4", @"v3", @"v2:f16c:fma", @"v8.3a:fp16")]
+    #[crate::multiversion(@"v4.512:avx512fp16", @"v4.512", @"v3", @"a3.512", @"a2:fp16")]
     pub fn reduce_sum_of_xy(lhs: &[f16], rhs: &[f16]) -> f32 {
         assert!(lhs.len() == rhs.len());
         let n = lhs.len();
@@ -579,9 +499,9 @@ mod reduce_sum_of_d2 {
 
     #[inline]
     #[cfg(target_arch = "x86_64")]
-    #[crate::target_cpu(enable = "v4")]
+    #[crate::target_cpu(enable = "v4.512")]
     #[target_feature(enable = "avx512fp16")]
-    pub fn reduce_sum_of_d2_v4_avx512fp16(lhs: &[f16], rhs: &[f16]) -> f32 {
+    pub fn reduce_sum_of_d2_v4_512_avx512fp16(lhs: &[f16], rhs: &[f16]) -> f32 {
         assert!(lhs.len() == rhs.len());
         unsafe {
             use std::arch::x86_64::*;
@@ -611,11 +531,11 @@ mod reduce_sum_of_d2 {
 
     #[cfg(all(target_arch = "x86_64", test, not(miri)))]
     #[test]
-    fn reduce_sum_of_d2_v4_avx512fp16_test() {
+    fn reduce_sum_of_d2_v4_512_avx512fp16_test() {
         use rand::Rng;
         const EPSILON: f32 = 6.0;
-        if !crate::is_cpu_detected!("v4") || !crate::is_feature_detected!("avx512fp16") {
-            println!("test {} ... skipped (v4:avx512fp16)", module_path!());
+        if !crate::is_cpu_detected!("v4.512") || !crate::is_feature_detected!("avx512fp16") {
+            println!("test {} ... skipped (v4_512:avx512fp16)", module_path!());
             return;
         }
         let mut rng = rand::rng();
@@ -630,8 +550,8 @@ mod reduce_sum_of_d2 {
             for z in 3984..4016 {
                 let lhs = &lhs[..z];
                 let rhs = &rhs[..z];
-                let specialized = unsafe { reduce_sum_of_d2_v4_avx512fp16(lhs, rhs) };
-                let fallback = reduce_sum_of_d2_fallback(lhs, rhs);
+                let specialized = unsafe { reduce_sum_of_d2_v4_512_avx512fp16(lhs, rhs) };
+                let fallback = fallback(lhs, rhs);
                 assert!(
                     (specialized - fallback).abs() < EPSILON,
                     "specialized = {specialized}, fallback = {fallback}."
@@ -642,8 +562,8 @@ mod reduce_sum_of_d2 {
 
     #[inline]
     #[cfg(target_arch = "x86_64")]
-    #[crate::target_cpu(enable = "v4")]
-    pub fn reduce_sum_of_d2_v4(lhs: &[f16], rhs: &[f16]) -> f32 {
+    #[crate::target_cpu(enable = "v4.512")]
+    pub fn reduce_sum_of_d2_v4_512(lhs: &[f16], rhs: &[f16]) -> f32 {
         assert!(lhs.len() == rhs.len());
         unsafe {
             use std::arch::x86_64::*;
@@ -676,7 +596,7 @@ mod reduce_sum_of_d2 {
     fn reduce_sum_of_d2_v4_test() {
         use rand::Rng;
         const EPSILON: f32 = 2.0;
-        if !crate::is_cpu_detected!("v4") {
+        if !crate::is_cpu_detected!("v4.512") {
             println!("test {} ... skipped (v4)", module_path!());
             return;
         }
@@ -692,8 +612,8 @@ mod reduce_sum_of_d2 {
             for z in 3984..4016 {
                 let lhs = &lhs[..z];
                 let rhs = &rhs[..z];
-                let specialized = unsafe { reduce_sum_of_d2_v4(lhs, rhs) };
-                let fallback = reduce_sum_of_d2_fallback(lhs, rhs);
+                let specialized = unsafe { reduce_sum_of_d2_v4_512(lhs, rhs) };
+                let fallback = fallback(lhs, rhs);
                 assert!(
                     (specialized - fallback).abs() < EPSILON,
                     "specialized = {specialized}, fallback = {fallback}."
@@ -759,78 +679,7 @@ mod reduce_sum_of_d2 {
                 let lhs = &lhs[..z];
                 let rhs = &rhs[..z];
                 let specialized = unsafe { reduce_sum_of_d2_v3(lhs, rhs) };
-                let fallback = reduce_sum_of_d2_fallback(lhs, rhs);
-                assert!(
-                    (specialized - fallback).abs() < EPSILON,
-                    "specialized = {specialized}, fallback = {fallback}."
-                );
-            }
-        }
-    }
-
-    #[inline]
-    #[cfg(target_arch = "x86_64")]
-    #[crate::target_cpu(enable = "v2")]
-    #[target_feature(enable = "f16c")]
-    #[target_feature(enable = "fma")]
-    pub fn reduce_sum_of_d2_v2_f16c_fma(lhs: &[f16], rhs: &[f16]) -> f32 {
-        use crate::emulate::emulate_mm_reduce_add_ps;
-        assert!(lhs.len() == rhs.len());
-        unsafe {
-            use std::arch::x86_64::*;
-            let mut n = lhs.len() as u32;
-            let mut a = lhs.as_ptr();
-            let mut b = rhs.as_ptr();
-            let mut d2 = _mm_setzero_ps();
-            while n >= 4 {
-                let x = _mm_cvtph_ps(_mm_loadu_si128(a.cast()));
-                let y = _mm_cvtph_ps(_mm_loadu_si128(b.cast()));
-                a = a.add(4);
-                b = b.add(4);
-                n -= 4;
-                let d = _mm_sub_ps(x, y);
-                d2 = _mm_fmadd_ps(d, d, d2);
-            }
-            let mut d2 = emulate_mm_reduce_add_ps(d2);
-            while n > 0 {
-                let x = a.read().to_f32();
-                let y = b.read().to_f32();
-                a = a.add(1);
-                b = b.add(1);
-                n -= 1;
-                let d = x - y;
-                d2 += d * d;
-            }
-            d2
-        }
-    }
-
-    #[cfg(all(target_arch = "x86_64", test, not(miri)))]
-    #[test]
-    fn reduce_sum_of_d2_v2_f16c_fma_test() {
-        use rand::Rng;
-        const EPSILON: f32 = 2.0;
-        if !crate::is_cpu_detected!("v2")
-            || !crate::is_feature_detected!("f16c")
-            || !crate::is_feature_detected!("fma")
-        {
-            println!("test {} ... skipped (v2:f16c:fma)", module_path!());
-            return;
-        }
-        let mut rng = rand::rng();
-        for _ in 0..if cfg!(not(miri)) { 256 } else { 1 } {
-            let n = 4016;
-            let lhs = (0..n)
-                .map(|_| f16::from_f32(rng.random_range(-1.0..=1.0)))
-                .collect::<Vec<_>>();
-            let rhs = (0..n)
-                .map(|_| f16::from_f32(rng.random_range(-1.0..=1.0)))
-                .collect::<Vec<_>>();
-            for z in 3984..4016 {
-                let lhs = &lhs[..z];
-                let rhs = &rhs[..z];
-                let specialized = unsafe { reduce_sum_of_d2_v2_f16c_fma(lhs, rhs) };
-                let fallback = reduce_sum_of_d2_fallback(lhs, rhs);
+                let fallback = fallback(lhs, rhs);
                 assert!(
                     (specialized - fallback).abs() < EPSILON,
                     "specialized = {specialized}, fallback = {fallback}."
@@ -841,33 +690,25 @@ mod reduce_sum_of_d2 {
 
     #[inline]
     #[cfg(target_arch = "aarch64")]
-    #[crate::target_cpu(enable = "v8.3a")]
+    #[crate::target_cpu(enable = "a2")]
     #[target_feature(enable = "fp16")]
-    pub fn reduce_sum_of_d2_v8_3a_fp16(lhs: &[f16], rhs: &[f16]) -> f32 {
+    pub fn reduce_sum_of_d2_a2_fp16(lhs: &[f16], rhs: &[f16]) -> f32 {
         assert!(lhs.len() == rhs.len());
         unsafe {
             extern "C" {
-                fn fp16_reduce_sum_of_d2_v8_3a_fp16_unroll(
-                    a: *const (),
-                    b: *const (),
-                    n: usize,
-                ) -> f32;
+                fn fp16_reduce_sum_of_d2_a2_fp16(a: *const (), b: *const (), n: usize) -> f32;
             }
-            fp16_reduce_sum_of_d2_v8_3a_fp16_unroll(
-                lhs.as_ptr().cast(),
-                rhs.as_ptr().cast(),
-                lhs.len(),
-            )
+            fp16_reduce_sum_of_d2_a2_fp16(lhs.as_ptr().cast(), rhs.as_ptr().cast(), lhs.len())
         }
     }
 
     #[cfg(all(target_arch = "aarch64", test, not(miri)))]
     #[test]
-    fn reduce_sum_of_d2_v8_3a_fp16_test() {
+    fn reduce_sum_of_d2_a2_fp16_test() {
         use rand::Rng;
         const EPSILON: f32 = 6.0;
-        if !crate::is_cpu_detected!("v8.3a") || !crate::is_feature_detected!("fp16") {
-            println!("test {} ... skipped (v8.3a:fp16)", module_path!());
+        if !crate::is_cpu_detected!("a2") || !crate::is_feature_detected!("fp16") {
+            println!("test {} ... skipped (a2:fp16)", module_path!());
             return;
         }
         let mut rng = rand::rng();
@@ -882,8 +723,8 @@ mod reduce_sum_of_d2 {
             for z in 3984..4016 {
                 let lhs = &lhs[..z];
                 let rhs = &rhs[..z];
-                let specialized = unsafe { reduce_sum_of_d2_v8_3a_fp16(lhs, rhs) };
-                let fallback = reduce_sum_of_d2_fallback(lhs, rhs);
+                let specialized = unsafe { reduce_sum_of_d2_a2_fp16(lhs, rhs) };
+                let fallback = fallback(lhs, rhs);
                 assert!(
                     (specialized - fallback).abs() < EPSILON,
                     "specialized = {specialized}, fallback = {fallback}."
@@ -892,30 +733,27 @@ mod reduce_sum_of_d2 {
         }
     }
 
-    // temporarily disables this for uncertain precision
-    #[cfg_attr(not(test), expect(dead_code))]
     #[inline]
     #[cfg(target_arch = "aarch64")]
-    #[crate::target_cpu(enable = "v8.3a")]
+    #[crate::target_cpu(enable = "a2")]
     #[target_feature(enable = "sve")]
-    pub fn reduce_sum_of_d2_v8_3a_sve(lhs: &[f16], rhs: &[f16]) -> f32 {
+    pub fn reduce_sum_of_d2_a3_512(lhs: &[f16], rhs: &[f16]) -> f32 {
         assert!(lhs.len() == rhs.len());
         unsafe {
             extern "C" {
-                fn fp16_reduce_sum_of_d2_v8_3a_sve(a: *const (), b: *const (), n: usize) -> f32;
+                fn fp16_reduce_sum_of_d2_a3_512(a: *const (), b: *const (), n: usize) -> f32;
             }
-            fp16_reduce_sum_of_d2_v8_3a_sve(lhs.as_ptr().cast(), rhs.as_ptr().cast(), lhs.len())
+            fp16_reduce_sum_of_d2_a3_512(lhs.as_ptr().cast(), rhs.as_ptr().cast(), lhs.len())
         }
     }
 
     #[cfg(all(target_arch = "aarch64", test, not(miri)))]
     #[test]
-    #[ignore]
-    fn reduce_sum_of_d2_v8_3a_sve_test() {
+    fn reduce_sum_of_d2_a3_512_test() {
         use rand::Rng;
         const EPSILON: f32 = 6.0;
-        if !crate::is_cpu_detected!("v8.3a") || !crate::is_feature_detected!("sve") {
-            println!("test {} ... skipped (v8.3a:sve)", module_path!());
+        if !crate::is_cpu_detected!("a3.512") {
+            println!("test {} ... skipped (a3.512)", module_path!());
             return;
         }
         let mut rng = rand::rng();
@@ -930,8 +768,8 @@ mod reduce_sum_of_d2 {
             for z in 3984..4016 {
                 let lhs = &lhs[..z];
                 let rhs = &rhs[..z];
-                let specialized = unsafe { reduce_sum_of_d2_v8_3a_sve(lhs, rhs) };
-                let fallback = reduce_sum_of_d2_fallback(lhs, rhs);
+                let specialized = unsafe { reduce_sum_of_d2_a3_512(lhs, rhs) };
+                let fallback = fallback(lhs, rhs);
                 assert!(
                     (specialized - fallback).abs() < EPSILON,
                     "specialized = {specialized}, fallback = {fallback}."
@@ -940,7 +778,7 @@ mod reduce_sum_of_d2 {
         }
     }
 
-    #[crate::multiversion(@"v4:avx512fp16", @"v4", @"v3", @"v2:f16c:fma", @"v8.3a:fp16")]
+    #[crate::multiversion(@"v4.512:avx512fp16", @"v4.512", @"v3", @"a3.512", @"a2:fp16")]
     pub fn reduce_sum_of_d2(lhs: &[f16], rhs: &[f16]) -> f32 {
         assert!(lhs.len() == rhs.len());
         let n = lhs.len();
@@ -959,7 +797,7 @@ mod reduce_sum_of_xy_sparse {
 
     use half::f16;
 
-    #[crate::multiversion("v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion("v4.512", "v3", "v2", "a2")]
     pub fn reduce_sum_of_xy_sparse(lidx: &[u32], lval: &[f16], ridx: &[u32], rval: &[f16]) -> f32 {
         use std::cmp::Ordering;
         assert_eq!(lidx.len(), lval.len());
@@ -992,7 +830,7 @@ mod reduce_sum_of_d2_sparse {
 
     use half::f16;
 
-    #[crate::multiversion("v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion("v4.512", "v3", "v2", "a2")]
     pub fn reduce_sum_of_d2_sparse(lidx: &[u32], lval: &[f16], ridx: &[u32], rval: &[f16]) -> f32 {
         use std::cmp::Ordering;
         assert_eq!(lidx.len(), lval.len());
@@ -1031,7 +869,7 @@ mod reduce_sum_of_d2_sparse {
 mod vector_add {
     use half::f16;
 
-    #[crate::multiversion("v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion("v4.512", "v3", "v2", "a2")]
     pub fn vector_add(lhs: &[f16], rhs: &[f16]) -> Vec<f16> {
         assert_eq!(lhs.len(), rhs.len());
         let n = lhs.len();
@@ -1051,7 +889,7 @@ mod vector_add {
 mod vector_add_inplace {
     use half::f16;
 
-    #[crate::multiversion("v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion("v4.512", "v3", "v2", "a2")]
     pub fn vector_add_inplace(lhs: &mut [f16], rhs: &[f16]) {
         assert_eq!(lhs.len(), rhs.len());
         let n = lhs.len();
@@ -1064,7 +902,7 @@ mod vector_add_inplace {
 mod vector_sub {
     use half::f16;
 
-    #[crate::multiversion("v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion("v4.512", "v3", "v2", "a2")]
     pub fn vector_sub(lhs: &[f16], rhs: &[f16]) -> Vec<f16> {
         assert_eq!(lhs.len(), rhs.len());
         let n = lhs.len();
@@ -1084,7 +922,7 @@ mod vector_sub {
 mod vector_mul {
     use half::f16;
 
-    #[crate::multiversion("v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion("v4.512", "v3", "v2", "a2")]
     pub fn vector_mul(lhs: &[f16], rhs: &[f16]) -> Vec<f16> {
         assert_eq!(lhs.len(), rhs.len());
         let n = lhs.len();
@@ -1104,7 +942,7 @@ mod vector_mul {
 mod vector_mul_scalar {
     use half::f16;
 
-    #[crate::multiversion("v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion("v4.512", "v3", "v2", "a2")]
     pub fn vector_mul_scalar(lhs: &[f16], rhs: f32) -> Vec<f16> {
         let rhs = f16::from_f32(rhs);
         let n = lhs.len();
@@ -1124,7 +962,7 @@ mod vector_mul_scalar {
 mod vector_mul_scalar_inplace {
     use half::f16;
 
-    #[crate::multiversion("v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion("v4.512", "v3", "v2", "a2")]
     pub fn vector_mul_scalar_inplace(lhs: &mut [f16], rhs: f32) {
         let rhs = f16::from_f32(rhs);
         let n = lhs.len();
@@ -1137,7 +975,7 @@ mod vector_mul_scalar_inplace {
 mod vector_abs_inplace {
     use half::f16;
 
-    #[crate::multiversion("v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion("v4.512", "v3", "v2", "a2")]
     pub fn vector_abs_inplace(this: &mut [f16]) {
         let n = this.len();
         for i in 0..n {
@@ -1149,7 +987,7 @@ mod vector_abs_inplace {
 mod vector_from_f32 {
     use half::f16;
 
-    #[crate::multiversion("v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion("v4.512", "v3", "v2", "a2")]
     pub fn vector_from_f32(this: &[f32]) -> Vec<f16> {
         let n = this.len();
         let mut r = Vec::<f16>::with_capacity(n);
@@ -1168,7 +1006,7 @@ mod vector_from_f32 {
 mod vector_to_f32 {
     use half::f16;
 
-    #[crate::multiversion("v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion("v4.512", "v3", "v2", "a2")]
     pub fn vector_to_f32(this: &[f16]) -> Vec<f32> {
         let n = this.len();
         let mut r = Vec::<f32>::with_capacity(n);

--- a/crates/simd/src/lib.rs
+++ b/crates/simd/src/lib.rs
@@ -68,6 +68,74 @@ mod internal {
     #[cfg(target_arch = "riscv64")]
     #[allow(unused_imports)]
     pub use is_riscv64_cpu_detected;
+
+    #[cfg(target_arch = "x86_64")]
+    pub fn is_v4_512_detected() -> bool {
+        std::arch::is_x86_feature_detected!("avx512bw")
+            && std::arch::is_x86_feature_detected!("avx512cd")
+            && std::arch::is_x86_feature_detected!("avx512dq")
+            && std::arch::is_x86_feature_detected!("avx512vl")
+            && std::arch::is_x86_feature_detected!("bmi1")
+            && std::arch::is_x86_feature_detected!("bmi2")
+            && std::arch::is_x86_feature_detected!("lzcnt")
+            && std::arch::is_x86_feature_detected!("movbe")
+            && std::arch::is_x86_feature_detected!("popcnt")
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    pub fn is_v3_detected() -> bool {
+        std::arch::is_x86_feature_detected!("avx2")
+            && std::arch::is_x86_feature_detected!("f16c")
+            && std::arch::is_x86_feature_detected!("fma")
+            && std::arch::is_x86_feature_detected!("bmi1")
+            && std::arch::is_x86_feature_detected!("bmi2")
+            && std::arch::is_x86_feature_detected!("lzcnt")
+            && std::arch::is_x86_feature_detected!("movbe")
+            && std::arch::is_x86_feature_detected!("popcnt")
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    pub fn is_v2_detected() -> bool {
+        std::arch::is_x86_feature_detected!("sse4.2")
+            && std::arch::is_x86_feature_detected!("popcnt")
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    pub fn is_a3_512_detected() -> bool {
+        #[target_feature(enable = "sve")]
+        fn is_512_detected() -> bool {
+            let vl: u64;
+            unsafe {
+                core::arch::asm!(
+                    "rdvl {0}, #2",
+                    out(reg) vl
+                );
+            }
+            vl >= 4
+        }
+        std::arch::is_aarch64_feature_detected!("sve") && unsafe { is_512_detected() }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    pub fn is_a3_256_detected() -> bool {
+        #[target_feature(enable = "sve")]
+        fn is_256_detected() -> bool {
+            let vl: u64;
+            unsafe {
+                core::arch::asm!(
+                    "rdvl {0}, #2",
+                    out(reg) vl
+                );
+            }
+            vl >= 2
+        }
+        std::arch::is_aarch64_feature_detected!("sve") && unsafe { is_256_detected() }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    pub fn is_a2_detected() -> bool {
+        std::arch::is_aarch64_feature_detected!("neon")
+    }
 }
 
 pub use simd_macros::{multiversion, target_cpu};

--- a/crates/simd/src/packed_u4.rs
+++ b/crates/simd/src/packed_u4.rs
@@ -3,7 +3,7 @@ pub fn reduce_sum_of_xy(s: &[u8], t: &[u8]) -> u32 {
 }
 
 mod reduce_sum_of_xy {
-    #[crate::multiversion("v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion("v4.512", "v3", "v2", "a2")]
     pub fn reduce_sum_of_xy(s: &[u8], t: &[u8]) -> u32 {
         assert_eq!(s.len(), t.len());
         let n = s.len();

--- a/crates/simd/src/quantize.rs
+++ b/crates/simd/src/quantize.rs
@@ -1,8 +1,8 @@
 mod mul_add_round {
     #[inline]
     #[cfg(target_arch = "x86_64")]
-    #[crate::target_cpu(enable = "v4")]
-    fn mul_add_round_v4(this: &[f32], k: f32, b: f32) -> Vec<u8> {
+    #[crate::target_cpu(enable = "v4.512")]
+    fn mul_add_round_v4_512(this: &[f32], k: f32, b: f32) -> Vec<u8> {
         let n = this.len();
         let mut r = Vec::<u8>::with_capacity(n);
         unsafe {
@@ -42,7 +42,7 @@ mod mul_add_round {
     #[cfg(all(target_arch = "x86_64", test, not(miri)))]
     #[test]
     fn mul_add_round_v4_test() {
-        if !crate::is_cpu_detected!("v4") {
+        if !crate::is_cpu_detected!("v4.512") {
             println!("test {} ... skipped (v4)", module_path!());
             return;
         }
@@ -53,8 +53,8 @@ mod mul_add_round {
                 let x = &x[..z];
                 let k = 20.0;
                 let b = 20.0;
-                let specialized = unsafe { mul_add_round_v4(x, k, b) };
-                let fallback = mul_add_round_fallback(x, k, b);
+                let specialized = unsafe { mul_add_round_v4_512(x, k, b) };
+                let fallback = fallback(x, k, b);
                 assert_eq!(specialized, fallback);
             }
         }
@@ -123,7 +123,7 @@ mod mul_add_round {
                 let k = 20.0;
                 let b = 20.0;
                 let specialized = unsafe { mul_add_round_v3(x, k, b) };
-                let fallback = mul_add_round_fallback(x, k, b);
+                let fallback = fallback(x, k, b);
                 assert_eq!(specialized, fallback);
             }
         }
@@ -189,7 +189,7 @@ mod mul_add_round {
                 let k = 20.0;
                 let b = 20.0;
                 let specialized = unsafe { mul_add_round_v2_fma(x, k, b) };
-                let fallback = mul_add_round_fallback(x, k, b);
+                let fallback = fallback(x, k, b);
                 assert_eq!(specialized, fallback);
             }
         }
@@ -197,8 +197,8 @@ mod mul_add_round {
 
     #[inline]
     #[cfg(target_arch = "aarch64")]
-    #[crate::target_cpu(enable = "v8.3a")]
-    fn mul_add_round_v8_3a(this: &[f32], k: f32, b: f32) -> Vec<u8> {
+    #[crate::target_cpu(enable = "a2")]
+    fn mul_add_round_a2(this: &[f32], k: f32, b: f32) -> Vec<u8> {
         let n = this.len();
         let mut r = Vec::<u8>::with_capacity(n);
         unsafe {
@@ -244,9 +244,9 @@ mod mul_add_round {
 
     #[cfg(all(target_arch = "aarch64", test, not(miri)))]
     #[test]
-    fn mul_add_round_v8_3a_test() {
-        if !crate::is_cpu_detected!("v8.3a") {
-            println!("test {} ... skipped (v8.3a)", module_path!());
+    fn mul_add_round_a2_test() {
+        if !crate::is_cpu_detected!("a2") {
+            println!("test {} ... skipped (a2)", module_path!());
             return;
         }
         for _ in 0..if cfg!(not(miri)) { 256 } else { 1 } {
@@ -256,14 +256,14 @@ mod mul_add_round {
                 let x = &x[..z];
                 let k = 20.0;
                 let b = 20.0;
-                let specialized = unsafe { mul_add_round_v8_3a(x, k, b) };
-                let fallback = mul_add_round_fallback(x, k, b);
+                let specialized = unsafe { mul_add_round_a2(x, k, b) };
+                let fallback = fallback(x, k, b);
                 assert_eq!(specialized, fallback);
             }
         }
     }
 
-    #[crate::multiversion(@"v4", @"v3", @"v2:fma", @"v8.3a")]
+    #[crate::multiversion(@"v4.512", @"v3", @"v2:fma", @"a2")]
     pub fn mul_add_round(this: &[f32], k: f32, b: f32) -> Vec<u8> {
         let n = this.len();
         let mut r = Vec::<u8>::with_capacity(n);

--- a/crates/simd/src/u8.rs
+++ b/crates/simd/src/u8.rs
@@ -1,5 +1,5 @@
 mod reduce_sum_of_xy {
-    #[crate::multiversion("v4", "v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion("v4.512", "v3", "v2", "a2")]
     pub fn reduce_sum_of_xy(s: &[u8], t: &[u8]) -> u32 {
         assert_eq!(s.len(), t.len());
         let n = s.len();
@@ -19,8 +19,8 @@ pub fn reduce_sum_of_xy(s: &[u8], t: &[u8]) -> u32 {
 mod reduce_sum_of_x_as_u16 {
     #[inline]
     #[cfg(target_arch = "x86_64")]
-    #[crate::target_cpu(enable = "v4")]
-    fn reduce_sum_of_x_as_u16_v4(this: &[u8]) -> u16 {
+    #[crate::target_cpu(enable = "v4.512")]
+    fn reduce_sum_of_x_as_u16_v4_512(this: &[u8]) -> u16 {
         use crate::emulate::emulate_mm512_reduce_add_epi16;
         unsafe {
             use std::arch::x86_64::*;
@@ -47,7 +47,7 @@ mod reduce_sum_of_x_as_u16 {
     #[test]
     fn reduce_sum_of_x_as_u16_v4_test() {
         use rand::Rng;
-        if !crate::is_cpu_detected!("v4") {
+        if !crate::is_cpu_detected!("v4.512") {
             println!("test {} ... skipped (v4)", module_path!());
             return;
         }
@@ -57,8 +57,8 @@ mod reduce_sum_of_x_as_u16 {
             let this = (0..n).map(|_| rng.random_range(0..16)).collect::<Vec<_>>();
             for z in 3984..4016 {
                 let this = &this[..z];
-                let specialized = unsafe { reduce_sum_of_x_as_u16_v4(this) };
-                let fallback = reduce_sum_of_x_as_u16_fallback(this);
+                let specialized = unsafe { reduce_sum_of_x_as_u16_v4_512(this) };
+                let fallback = fallback(this);
                 assert_eq!(specialized, fallback);
             }
         }
@@ -108,7 +108,7 @@ mod reduce_sum_of_x_as_u16 {
             for z in 3984..4016 {
                 let this = &this[..z];
                 let specialized = unsafe { reduce_sum_of_x_as_u16_v3(this) };
-                let fallback = reduce_sum_of_x_as_u16_fallback(this);
+                let fallback = fallback(this);
                 assert_eq!(specialized, fallback);
             }
         }
@@ -158,7 +158,7 @@ mod reduce_sum_of_x_as_u16 {
             for z in 3984..4016 {
                 let this = &this[..z];
                 let specialized = unsafe { reduce_sum_of_x_as_u16_v2(this) };
-                let fallback = reduce_sum_of_x_as_u16_fallback(this);
+                let fallback = fallback(this);
                 assert_eq!(specialized, fallback);
             }
         }
@@ -166,8 +166,8 @@ mod reduce_sum_of_x_as_u16 {
 
     #[inline]
     #[cfg(target_arch = "aarch64")]
-    #[crate::target_cpu(enable = "v8.3a")]
-    fn reduce_sum_of_x_as_u16_v8_3a(this: &[u8]) -> u16 {
+    #[crate::target_cpu(enable = "a2")]
+    fn reduce_sum_of_x_as_u16_a2(this: &[u8]) -> u16 {
         unsafe {
             use std::arch::aarch64::*;
             let us = vdupq_n_u16(255);
@@ -194,10 +194,10 @@ mod reduce_sum_of_x_as_u16 {
 
     #[cfg(all(target_arch = "aarch64", test, not(miri)))]
     #[test]
-    fn reduce_sum_of_x_as_u16_v8_3a_test() {
+    fn reduce_sum_of_x_as_u16_a2_test() {
         use rand::Rng;
-        if !crate::is_cpu_detected!("v8.3a") {
-            println!("test {} ... skipped (v8.3a)", module_path!());
+        if !crate::is_cpu_detected!("a2") {
+            println!("test {} ... skipped (a2)", module_path!());
             return;
         }
         let mut rng = rand::rng();
@@ -206,14 +206,14 @@ mod reduce_sum_of_x_as_u16 {
             let this = (0..n).map(|_| rng.random_range(0..16)).collect::<Vec<_>>();
             for z in 3984..4016 {
                 let this = &this[..z];
-                let specialized = unsafe { reduce_sum_of_x_as_u16_v8_3a(this) };
-                let fallback = reduce_sum_of_x_as_u16_fallback(this);
+                let specialized = unsafe { reduce_sum_of_x_as_u16_a2(this) };
+                let fallback = fallback(this);
                 assert_eq!(specialized, fallback);
             }
         }
     }
 
-    #[crate::multiversion(@"v4", @"v3", @"v2", @"v8.3a")]
+    #[crate::multiversion(@"v4.512", @"v3", @"v2", @"a2")]
     pub fn reduce_sum_of_x_as_u16(this: &[u8]) -> u16 {
         let n = this.len();
         let mut sum = 0;
@@ -232,8 +232,8 @@ pub fn reduce_sum_of_x_as_u16(vector: &[u8]) -> u16 {
 mod reduce_sum_of_x {
     #[inline]
     #[cfg(target_arch = "x86_64")]
-    #[crate::target_cpu(enable = "v4")]
-    fn reduce_sum_of_x_v4(this: &[u8]) -> u32 {
+    #[crate::target_cpu(enable = "v4.512")]
+    fn reduce_sum_of_x_v4_512(this: &[u8]) -> u32 {
         unsafe {
             use std::arch::x86_64::*;
             let us = _mm512_set1_epi32(255);
@@ -259,7 +259,7 @@ mod reduce_sum_of_x {
     #[test]
     fn reduce_sum_of_x_v4_test() {
         use rand::Rng;
-        if !crate::is_cpu_detected!("v4") {
+        if !crate::is_cpu_detected!("v4.512") {
             println!("test {} ... skipped (v4)", module_path!());
             return;
         }
@@ -269,8 +269,8 @@ mod reduce_sum_of_x {
             let this = (0..n).map(|_| rng.random_range(0..16)).collect::<Vec<_>>();
             for z in 3984..4016 {
                 let this = &this[..z];
-                let specialized = unsafe { reduce_sum_of_x_v4(this) };
-                let fallback = reduce_sum_of_x_fallback(this);
+                let specialized = unsafe { reduce_sum_of_x_v4_512(this) };
+                let fallback = fallback(this);
                 assert_eq!(specialized, fallback);
             }
         }
@@ -320,13 +320,13 @@ mod reduce_sum_of_x {
             for z in 3984..4016 {
                 let this = &this[..z];
                 let specialized = unsafe { reduce_sum_of_x_v3(this) };
-                let fallback = reduce_sum_of_x_fallback(this);
+                let fallback = fallback(this);
                 assert_eq!(specialized, fallback);
             }
         }
     }
 
-    #[crate::multiversion(@"v4", @"v3", "v2", "v8.3a:sve", "v8.3a")]
+    #[crate::multiversion(@"v4.512", @"v3", "v2", "a2")]
     pub fn reduce_sum_of_x(this: &[u8]) -> u32 {
         let n = this.len();
         let mut sum = 0;

--- a/crates/simd_macros/src/target.rs
+++ b/crates/simd_macros/src/target.rs
@@ -6,78 +6,48 @@ pub struct TargetCpu {
 
 pub const TARGET_CPUS: &[TargetCpu] = &[
     TargetCpu {
-        target_cpu: "v4",
+        target_cpu: "v4.512",
         target_arch: "x86_64",
         target_features: &[
-            "avx",
-            "avx2",
-            "avx512bw",
-            "avx512cd",
-            "avx512dq",
-            "avx512f",
-            "avx512vl",
-            "bmi1",
-            "bmi2",
-            "cmpxchg16b",
-            "f16c",
-            "fma",
-            "fxsr",
-            "lzcnt",
-            "movbe",
-            "popcnt",
-            "sse",
-            "sse2",
-            "sse3",
-            "sse4.1",
-            "sse4.2",
-            "ssse3",
-            "xsave",
+            "avx512bw", "avx512cd", "avx512dq", "avx512vl", // simd
+            "bmi1", "bmi2", "lzcnt", "movbe", "popcnt", // bit-operations
         ],
     },
     TargetCpu {
         target_cpu: "v3",
         target_arch: "x86_64",
         target_features: &[
-            "avx",
-            "avx2",
-            "bmi1",
-            "bmi2",
-            "cmpxchg16b",
-            "f16c",
-            "fma",
-            "fxsr",
-            "lzcnt",
-            "movbe",
-            "popcnt",
-            "sse",
-            "sse2",
-            "sse3",
-            "sse4.1",
-            "sse4.2",
-            "ssse3",
-            "xsave",
+            "avx2", "f16c", "fma", // simd
+            "bmi1", "bmi2", "lzcnt", "movbe", "popcnt", // bit-operations
         ],
     },
     TargetCpu {
         target_cpu: "v2",
         target_arch: "x86_64",
         target_features: &[
-            "cmpxchg16b",
-            "fxsr",
-            "popcnt",
-            "sse",
-            "sse2",
-            "sse3",
-            "sse4.1",
-            "sse4.2",
-            "ssse3",
+            "sse4.2", // simd
+            "popcnt", // bit-operations
         ],
     },
     TargetCpu {
-        target_cpu: "v8.3a",
+        target_cpu: "a3.512",
         target_arch: "aarch64",
         target_features: &[
-            "crc", "dpb", "fcma", "jsconv", "lse", "neon", "paca", "pacg", "rcpc", "rdm",
+            "sve", // simd
+        ],
+    },
+    TargetCpu {
+        target_cpu: "a3.256",
+        target_arch: "aarch64",
+        target_features: &[
+            "sve", // simd
+        ],
+    },
+    TargetCpu {
+        target_cpu: "a2",
+        target_arch: "aarch64",
+        target_features: &[
+            "neon", // simd
         ],
     },
 ];

--- a/src/index/functions.rs
+++ b/src/index/functions.rs
@@ -19,7 +19,7 @@ fn _vchordrq_prewarm(indexrelid: Oid, height: i32) -> String {
     if pg_class.relam() != pg_am.oid() {
         pgrx::error!("{:?} is not a vchordrq index", pg_class.relname());
     }
-    let index = unsafe { pgrx::pg_sys::index_open(indexrelid, pgrx::pg_sys::ShareLock as _) };
+    let index = unsafe { pgrx::pg_sys::index_open(indexrelid, pgrx::pg_sys::AccessShareLock as _) };
     let relation = unsafe { PostgresRelation::new(index) };
     let opfamily = unsafe { crate::index::opclass::opfamily(index) };
     let message = match (opfamily.vector_kind(), opfamily.distance_kind()) {
@@ -45,7 +45,7 @@ fn _vchordrq_prewarm(indexrelid: Oid, height: i32) -> String {
         }
     };
     unsafe {
-        pgrx::pg_sys::index_close(index, pgrx::pg_sys::ShareLock as _);
+        pgrx::pg_sys::index_close(index, pgrx::pg_sys::AccessShareLock as _);
     }
     message
 }


### PR DESCRIPTION
1. only check simd-related features when dispatching
2. choose SVE implementation only if SVE bits >= 256
3. choose SVE f16 `sum_of_d2` and `sum_of_xy` implementation only if SVE bits >= 512