### PR TITLE
fix: test simd operations in emulator

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -74,6 +74,20 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
+      - name: Set up Environment
+        run: |
+          sudo apt-get update
+
+          if [ "$(uname -m)" == "x86_64" ]; then
+            wget https://downloadmirror.intel.com/843185/sde-external-9.48.0-2024-11-25-lin.tar.xz -O /tmp/sde-external.tar.xz
+            sudo tar -xf /tmp/sde-external.tar.xz -C /opt
+            sudo mv /opt/sde-external-9.48.0-2024-11-25-lin /opt/sde
+          fi
+
+          if [ "$(uname -m)" == "aarch64" ]; then
+            sudo apt-get install -y qemu-user-static
+          fi
+
       - name: Set up Sccache
         uses: mozilla-actions/sccache-action@v0.0.7
 
@@ -84,7 +98,22 @@ jobs:
         run: cargo clippy --workspace --exclude vchord
 
       - name: Cargo Test
-        run: cargo test --workspace --exclude vchord --no-fail-fast
+        run: cargo test --workspace --exclude vchord --exclude simd --no-fail-fast
+
+      - name: Cargo Test (simd)
+        run: |
+          cargo test -p simd --release -- --nocapture
+
+          if [ "$(uname -m)" == "x86_64" ]; then
+            cargo \
+              --config 'target.'\''cfg(all())'\''.runner = ["/opt/sde/sde64", "-spr", "--"]' \
+              test -p simd --release -- --nocapture
+          fi
+          if [ "$(uname -m)" == "aarch64" ]; then
+            cargo \
+              --config 'target.'\''cfg(all())'\''.runner = ["qemu-aarch64-static", "-cpu", "max"]' \
+              test -p simd --release -- --nocapture
+          fi
 
   psql:
     strategy:
@@ -96,6 +125,8 @@ jobs:
     steps:
       - name: Set up Environment
         run: |
+          sudo apt-get update
+
           sudo apt-get remove -y '^postgres.*' '^libpq.*'
           sudo apt-get purge -y '^postgres.*' '^libpq.*'
 

--- a/crates/simd/src/lib.rs
+++ b/crates/simd/src/lib.rs
@@ -107,11 +107,11 @@ mod internal {
             let vl: u64;
             unsafe {
                 core::arch::asm!(
-                    "rdvl {0}, #2",
+                    "rdvl {0}, #8",
                     out(reg) vl
                 );
             }
-            vl >= 4
+            vl >= 512
         }
         std::arch::is_aarch64_feature_detected!("sve") && unsafe { is_512_detected() }
     }
@@ -123,11 +123,11 @@ mod internal {
             let vl: u64;
             unsafe {
                 core::arch::asm!(
-                    "rdvl {0}, #2",
+                    "rdvl {0}, #8",
                     out(reg) vl
                 );
             }
-            vl >= 2
+            vl >= 256
         }
         std::arch::is_aarch64_feature_detected!("sve") && unsafe { is_256_detected() }
     }


### PR DESCRIPTION
1. x86_64 runner may not have avx512fp16 feature, so intel SDE is necessary for testing
2. aarch64 runner has short SVE bits, and cannot be used for testing SVE-256 implementation and SVE-512 implementation, so qemu is necessary for testing
