### PR TITLE
feat: encode kmeans progress to phase name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1164,6 +1164,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,6 +1506,7 @@ dependencies = [
  "pgrx-catalog",
  "rand",
  "random_orthogonal_matrix",
+ "seq-macro",
  "serde",
  "simd",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ paste.workspace = true
 pgrx = { version = "=0.13.1", default-features = false, features = ["cshim"] }
 pgrx-catalog = "0.1.1"
 rand.workspace = true
+seq-macro = "0.3.6"
 serde.workspace = true
 toml = "0.8.20"
 validator.workspace = true

--- a/README.md
+++ b/README.md
@@ -110,8 +110,7 @@ Now you can play with VectorChord!
   - [Indexing Prewarm](#indexing-prewarm)
   - [Indexing Progress](#indexing-progress)
   - [External Index Precomputation](#external-index-precomputation)
-  <!--TODO: Here we have a memory leak in rerank_in_table, show it until the feature is ready
-  - [Capacity-optimized Index](#capacity-optimized-index) -->
+  - [Capacity-optimized Index](#capacity-optimized-index)
   - [Range Query](#range-query)
 
 ## Installation
@@ -377,8 +376,6 @@ $$);
 
 To simplify the workflow, we provide end-to-end scripts for external index pre-computation, see [scripts](./scripts/README.md#run-external-index-precomputation-toolkit).
 
-<!-- TODO: Here we have a memory leak in rerank_in_table, show it until the feature is ready
-
 ### Capacity-optimized Index
 
 The default behavior of Vectorchord is `performance-optimized`, 
@@ -394,14 +391,12 @@ CREATE INDEX ON items USING vchordrq (embedding vector_l2_ops) WITH (options = $
 residual_quantization = true
 rerank_in_table = true
 [build.internal]
-...
+lists = []
 $$);
 ```
 
 > [!CAUTION]
 > Compared to the `performance-optimized` index, the `capacity-optimized` index will have a **30-50%** increase in latency and QPS loss at query.
-
--->
 
 ### Range Query
 

--- a/crates/k_means/src/lib.rs
+++ b/crates/k_means/src/lib.rs
@@ -21,7 +21,7 @@ pub fn preprocess<T: Send>(num_threads: usize, x: &mut [T], f: impl Fn(&mut T) +
 
 pub fn k_means(
     num_threads: usize,
-    check: impl Fn(usize),
+    mut check: impl FnMut(usize),
     c: usize,
     dims: usize,
     samples: &[Vec<f32>],

--- a/src/index/gucs.rs
+++ b/src/index/gucs.rs
@@ -8,6 +8,7 @@ static PREWARM_DIM: GucSetting<Option<&CStr>> =
     GucSetting::<Option<&CStr>>::new(Some(c"64,128,256,384,512,768,1024,1536"));
 static MAX_MAXSIM_TUPLES: GucSetting<i32> = GucSetting::<i32>::new(-1);
 static MAXSIM_THRESHOLD: GucSetting<i32> = GucSetting::<i32>::new(0);
+static PRERERANK_FILTERING: GucSetting<bool> = GucSetting::<bool>::new(false);
 
 pub fn init() {
     GucRegistry::define_string_guc(
@@ -63,6 +64,14 @@ pub fn init() {
         &MAXSIM_THRESHOLD,
         0,
         i32::MAX,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+    GucRegistry::define_bool_guc(
+        "vchordrq.prererank_filtering",
+        "`prererank_filtering` argument of vchordrq.",
+        "`prererank_filtering` argument of vchordrq.",
+        &PRERERANK_FILTERING,
         GucContext::Userset,
         GucFlags::default(),
     );
@@ -140,4 +149,8 @@ pub fn prewarm_dim() -> Vec<u32> {
     } else {
         Vec::new()
     }
+}
+
+pub fn prererank_filtering() -> bool {
+    PRERERANK_FILTERING.get()
 }

--- a/tests/logic/rerank_in_table.slt
+++ b/tests/logic/rerank_in_table.slt
@@ -79,6 +79,18 @@ SELECT id FROM t_expr WHERE id <= 5 OR id % 2 = 1 ORDER BY ARRAY[id::real, id::r
 11
 13
 
+statement ok
+SET vchordrq.prererank_filtering to off;
+
+query I
+SELECT ARRAY(SELECT id FROM t_expr WHERE (id <= 5 OR id % 2 = 1) OR e >= 2000 ORDER BY ARRAY[id::real, id::real, id::real]::vector(3) <-> q LIMIT 9) FROM (VALUES ('[1.9,1.99,1.999]'::vector, 1999), ('[2.1,2.11,2.111]', 2111)) AS t(q, e);
+----
+{2,1,3,4,5,7,9,11,13}
+{2,3,1,4,5,6,7,8,9}
+
+statement ok
+SET vchordrq.prererank_filtering to on;
+
 query I
 SELECT ARRAY(SELECT id FROM t_expr WHERE (id <= 5 OR id % 2 = 1) OR e >= 2000 ORDER BY ARRAY[id::real, id::real, id::real]::vector(3) <-> q LIMIT 9) FROM (VALUES ('[1.9,1.99,1.999]'::vector, 1999), ('[2.1,2.11,2.111]', 2111)) AS t(q, e);
 ----


### PR DESCRIPTION
* encode kmeans progress to build subphase names
* add a new GUC `vchordrq.prererank_filtering` (default to `off`) to control prererank filtering

Kmeans progress phase names look like it.

```
usamoi=# select * from pg_stat_progress_create_index ;
  pid   | datid | datname |  relid  | index_relid | command |                            phase                             | lockers_total | lockers_done | current_locker_pid | blo
cks_total | blocks_done | tuples_total | tuples_done | partitions_total | partitions_done 
--------+-------+---------+---------+-------------+---------+--------------------------------------------------------------+---------------+--------------+--------------------+----
----------+-------------+--------------+-------------+------------------+-----------------
 156193 | 16385 | usamoi  | 1444276 |     3091227 | REINDEX | building index: initializing index, by internal build (60 %) |             0 |            0 |                  0 |    
        0 |           0 |      1000000 |           0 |                0 |               0
(1 row)
```