### PR TITLE
chore: change default lists and probes to empty

### DIFF
--- a/src/index/gucs.rs
+++ b/src/index/gucs.rs
@@ -1,7 +1,7 @@
 use pgrx::guc::{GucContext, GucFlags, GucRegistry, GucSetting};
 use std::ffi::CStr;
 
-static PROBES: GucSetting<Option<&'static CStr>> = GucSetting::<Option<&CStr>>::new(Some(c"10"));
+static PROBES: GucSetting<Option<&'static CStr>> = GucSetting::<Option<&CStr>>::new(Some(c""));
 static EPSILON: GucSetting<f64> = GucSetting::<f64>::new(1.9);
 static MAX_SCAN_TUPLES: GucSetting<i32> = GucSetting::<i32>::new(-1);
 static PREWARM_DIM: GucSetting<Option<&CStr>> =

--- a/src/index/types.rs
+++ b/src/index/types.rs
@@ -23,7 +23,7 @@ pub struct VchordrqInternalBuildOptions {
 
 impl VchordrqInternalBuildOptions {
     fn default_lists() -> Vec<u32> {
-        vec![1000]
+        Vec::new()
     }
     fn validate_lists(lists: &[u32]) -> Result<(), ValidationError> {
         if !lists.is_sorted() {

--- a/tests/logic/index.slt
+++ b/tests/logic/index.slt
@@ -38,6 +38,9 @@ lists = [32]
 spherical_centroids = true
 $$);
 
+statement ok
+SET vchordrq.probes = '16';
+
 query I
 SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <-> '[0.5,0.5,0.5]' limit 10) t2;
 ----

--- a/tests/logic/partition.slt
+++ b/tests/logic/partition.slt
@@ -1,51 +1,51 @@
 # partition table
 statement ok
-CREATE TABLE items (val vector(3), category_id int) PARTITION BY LIST(category_id);
+CREATE TABLE t (val vector(3), category_id int) PARTITION BY LIST(category_id);
 
 statement ok
-CREATE TABLE id_123 PARTITION OF items FOR VALUES IN (1, 2, 3);
+CREATE TABLE id_123 PARTITION OF t FOR VALUES IN (1, 2, 3);
 
 statement ok
-CREATE TABLE id_456 PARTITION OF items FOR VALUES IN (4, 5, 6);
+CREATE TABLE id_456 PARTITION OF t FOR VALUES IN (4, 5, 6);
 
 statement ok
-CREATE TABLE id_789 PARTITION OF items FOR VALUES IN (7, 8, 9);
+CREATE TABLE id_789 PARTITION OF t FOR VALUES IN (7, 8, 9);
 
 statement ok
-INSERT INTO items (val, category_id)
+INSERT INTO t (val, category_id)
 SELECT
   ARRAY[random(), random(), random()]::real[],
   (random() * 6 + 1)::int
 FROM generate_series(1, 1000);
 
 statement ok
-CREATE INDEX ON items USING vchordrq (val public.vector_l2_ops);
+CREATE INDEX ON t USING vchordrq (val public.vector_l2_ops);
 
 query I
-SELECT COUNT(1) FROM (SELECT 1 FROM items ORDER BY val <-> '[0.5,0.5,0.5]' limit 10) t2;
+SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <-> '[0.5,0.5,0.5]' limit 10) t2;
 ----
 10
 
-statement error the relation "items_val_idx" is not an index
-select vchordrq_prewarm('items_val_idx');
+statement error the relation "t_val_idx" is not an index
+select vchordrq_prewarm('t_val_idx');
 
 statement ok
 CREATE INDEX ON id_123 USING vchordrq (val vector_cosine_ops);
 
 query I
-SELECT COUNT(1) FROM (SELECT 1 FROM items ORDER BY val <=> '[0.5,0.5,0.5]' limit 10) t2;
+SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <=> '[0.5,0.5,0.5]' limit 10) t2;
 ----
 10
 
 # partial index
 statement ok
-CREATE INDEX ON items USING vchordrq (val public.vector_ip_ops) WHERE (category_id = 1);
+CREATE INDEX ON t USING vchordrq (val public.vector_ip_ops) WHERE (category_id = 1);
 
 query I
 SELECT COUNT(1) FROM
-(SELECT 1 FROM items WHERE (category_id = 1) ORDER BY val <#> '[0.5,0.5,0.5]' limit 10) t2;
+(SELECT 1 FROM t WHERE (category_id = 1) ORDER BY val <#> '[0.5,0.5,0.5]' limit 10) t2;
 ----
 10
 
 statement ok
-DROP TABLE id_789, id_456, id_123, items;
+DROP TABLE id_789, id_456, id_123, t;


### PR DESCRIPTION
This changes default `lists` from `[1000]` to `[]`, and default `probes` to `10` to ` `.

The default value of `1000/10` is too small for big data and may cause issues for small data.

`lists = []` implies "clusters are not used, and all data are in the same set". It's good for small data.