### PR TITLE
refactor: remove allows_skipping_rerank

### DIFF
--- a/crates/algorithm/src/bulkdelete.rs
+++ b/crates/algorithm/src/bulkdelete.rs
@@ -1,12 +1,12 @@
 use crate::operator::{FunctionalAccessor, Operator};
 use crate::tuples::*;
 use crate::{Page, RelationWrite, tape};
-use std::num::NonZeroU64;
+use std::num::NonZero;
 
 pub fn bulkdelete<O: Operator>(
     index: impl RelationWrite,
     check: impl Fn(),
-    callback: impl Fn(NonZeroU64) -> bool,
+    callback: impl Fn(NonZero<u64>) -> bool,
 ) {
     let meta_guard = index.read(0);
     let meta_bytes = meta_guard.get(1).expect("data corruption");

--- a/crates/algorithm/src/lib.rs
+++ b/crates/algorithm/src/lib.rs
@@ -22,8 +22,8 @@ pub use cache::cache;
 pub use insert::insert;
 pub use maintain::maintain;
 pub use prewarm::prewarm;
-pub use rerank::{how, rerank_heap, rerank_index, skip};
-pub use search::{search, search_and_estimate};
+pub use rerank::{how, rerank_heap, rerank_index};
+pub use search::{default_search, maxsim_search};
 
 use std::ops::{Deref, DerefMut};
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};

--- a/crates/algorithm/src/operator.rs
+++ b/crates/algorithm/src/operator.rs
@@ -1,4 +1,3 @@
-use crate::types::*;
 use distance::Distance;
 use half::f16;
 use rabitq::binary::{BinaryCode, BinaryLut};
@@ -48,198 +47,6 @@ impl<E0, E1, M0: Copy, M1: Copy, A: Accessor2<E0, E1, M0, M1>, B: Accessor2<E0, 
 
     fn finish(self, input: M0, target: M1) -> Self::Output {
         (self.0.finish(input, target), self.1.finish(input, target))
-    }
-}
-
-#[derive(Debug)]
-pub struct Sum<O>(f32, PhantomData<fn(O) -> O>);
-
-impl<O> Default for Sum<O> {
-    fn default() -> Self {
-        Self(0.0, PhantomData)
-    }
-}
-
-impl Accessor2<f32, f32, (), ()> for Sum<Op<VectOwned<f32>, L2>> {
-    type Output = Distance;
-
-    fn push(&mut self, target: &[f32], input: &[f32]) {
-        self.0 += f32::reduce_sum_of_d2(target, input)
-    }
-
-    fn finish(self, (): (), (): ()) -> Self::Output {
-        Distance::from_f32(self.0)
-    }
-}
-
-impl Accessor2<f32, f32, (), ()> for Sum<Op<VectOwned<f32>, Dot>> {
-    type Output = Distance;
-
-    fn push(&mut self, target: &[f32], input: &[f32]) {
-        self.0 += f32::reduce_sum_of_xy(target, input)
-    }
-
-    fn finish(self, (): (), (): ()) -> Self::Output {
-        Distance::from_f32(-self.0)
-    }
-}
-
-impl Accessor2<f16, f16, (), ()> for Sum<Op<VectOwned<f16>, L2>> {
-    type Output = Distance;
-
-    fn push(&mut self, target: &[f16], input: &[f16]) {
-        self.0 += f16::reduce_sum_of_d2(target, input)
-    }
-
-    fn finish(self, (): (), (): ()) -> Self::Output {
-        Distance::from_f32(self.0)
-    }
-}
-
-impl Accessor2<f16, f16, (), ()> for Sum<Op<VectOwned<f16>, Dot>> {
-    type Output = Distance;
-
-    fn push(&mut self, target: &[f16], input: &[f16]) {
-        self.0 += f16::reduce_sum_of_xy(target, input)
-    }
-
-    fn finish(self, (): (), (): ()) -> Self::Output {
-        Distance::from_f32(-self.0)
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct Diff<O: Operator>(Vec<<O::Vector as Vector>::Element>);
-
-impl<O: Operator> Default for Diff<O> {
-    fn default() -> Self {
-        Self(Vec::new())
-    }
-}
-
-impl Accessor2<f32, f32, (), ()> for Diff<Op<VectOwned<f32>, L2>> {
-    type Output = VectOwned<f32>;
-
-    fn push(&mut self, target: &[f32], input: &[f32]) {
-        self.0.extend(f32::vector_sub(target, input));
-    }
-
-    fn finish(self, (): (), (): ()) -> Self::Output {
-        VectOwned::new(self.0)
-    }
-}
-
-impl Accessor2<f32, f32, (), ()> for Diff<Op<VectOwned<f32>, Dot>> {
-    type Output = VectOwned<f32>;
-
-    fn push(&mut self, target: &[f32], input: &[f32]) {
-        self.0.extend(f32::vector_sub(target, input));
-    }
-
-    fn finish(self, (): (), (): ()) -> Self::Output {
-        VectOwned::new(self.0)
-    }
-}
-
-impl Accessor2<f16, f16, (), ()> for Diff<Op<VectOwned<f16>, L2>> {
-    type Output = VectOwned<f16>;
-
-    fn push(&mut self, target: &[f16], input: &[f16]) {
-        self.0.extend(f16::vector_sub(target, input));
-    }
-
-    fn finish(self, (): (), (): ()) -> Self::Output {
-        VectOwned::new(self.0)
-    }
-}
-
-impl Accessor2<f16, f16, (), ()> for Diff<Op<VectOwned<f16>, Dot>> {
-    type Output = VectOwned<f16>;
-
-    fn push(&mut self, target: &[f16], input: &[f16]) {
-        self.0.extend(f16::vector_sub(target, input));
-    }
-
-    fn finish(self, (): (), (): ()) -> Self::Output {
-        VectOwned::new(self.0)
-    }
-}
-
-#[derive(Debug)]
-pub struct Block<D: OperatorDistance>([u16; 32], PhantomData<fn(D) -> D>);
-
-impl<D: OperatorDistance> Default for Block<D> {
-    fn default() -> Self {
-        Self([0u16; 32], PhantomData)
-    }
-}
-
-impl
-    Accessor2<
-        [u8; 16],
-        [u8; 16],
-        (&[f32; 32], &[f32; 32], &[f32; 32], &[f32; 32]),
-        ((f32, f32, f32, f32), f32),
-    > for Block<L2>
-{
-    type Output = [Distance; 32];
-
-    fn push(&mut self, input: &[[u8; 16]], target: &[[u8; 16]]) {
-        let t = simd::fast_scan::scan(input, target);
-        for i in 0..32 {
-            self.0[i] += t[i];
-        }
-    }
-
-    fn finish(
-        self,
-        (dis_u_2, factor_ppc, factor_ip, factor_err): (
-            &[f32; 32],
-            &[f32; 32],
-            &[f32; 32],
-            &[f32; 32],
-        ),
-        ((dis_v_2, b, k, qvector_sum), epsilon): ((f32, f32, f32, f32), f32),
-    ) -> Self::Output {
-        std::array::from_fn(|i| {
-            let rough = dis_u_2[i]
-                + dis_v_2
-                + b * factor_ppc[i]
-                + ((2.0 * self.0[i] as f32) - qvector_sum) * factor_ip[i] * k;
-            let err = factor_err[i] * dis_v_2.sqrt();
-            Distance::from_f32(rough - epsilon * err)
-        })
-    }
-}
-
-impl
-    Accessor2<
-        [u8; 16],
-        [u8; 16],
-        (&[f32; 32], &[f32; 32], &[f32; 32], &[f32; 32]),
-        ((f32, f32, f32, f32), f32),
-    > for Block<Dot>
-{
-    type Output = [Distance; 32];
-
-    fn push(&mut self, input: &[[u8; 16]], target: &[[u8; 16]]) {
-        let t = simd::fast_scan::scan(input, target);
-        for i in 0..32 {
-            self.0[i] += t[i];
-        }
-    }
-
-    fn finish(
-        self,
-        (_, factor_ppc, factor_ip, factor_err): (&[f32; 32], &[f32; 32], &[f32; 32], &[f32; 32]),
-        ((dis_v_2, b, k, qvector_sum), epsilon): ((f32, f32, f32, f32), f32),
-    ) -> Self::Output {
-        std::array::from_fn(|i| {
-            let rough = 0.5 * b * factor_ppc[i]
-                + 0.5 * ((2.0 * self.0[i] as f32) - qvector_sum) * factor_ip[i] * k;
-            let err = 0.5 * factor_err[i] * dis_v_2.sqrt();
-            Distance::from_f32(rough - epsilon * err)
-        })
     }
 }
 
@@ -377,17 +184,186 @@ impl<E0, E1, M0, M1, A: Accessor2<E0, E1, M0, M1>> Accessor1<E0, M0> for RAccess
     }
 }
 
+#[derive(Debug)]
+pub struct BlockAccessor<D>([u16; 32], PhantomData<fn(D) -> D>);
+
+impl<D> Default for BlockAccessor<D> {
+    fn default() -> Self {
+        Self([0u16; 32], PhantomData)
+    }
+}
+
+impl
+    Accessor2<
+        [u8; 16],
+        [u8; 16],
+        (&[f32; 32], &[f32; 32], &[f32; 32], &[f32; 32]),
+        (f32, f32, f32, f32),
+    > for BlockAccessor<L2>
+{
+    type Output = [(f32, f32); 32];
+
+    fn push(&mut self, input: &[[u8; 16]], target: &[[u8; 16]]) {
+        let t = simd::fast_scan::scan(input, target);
+        for i in 0..32 {
+            self.0[i] += t[i];
+        }
+    }
+
+    fn finish(
+        self,
+        (dis_u_2, factor_ppc, factor_ip, factor_err): (
+            &[f32; 32],
+            &[f32; 32],
+            &[f32; 32],
+            &[f32; 32],
+        ),
+        (dis_v_2, b, k, qvector_sum): (f32, f32, f32, f32),
+    ) -> Self::Output {
+        std::array::from_fn(|i| {
+            let rough = dis_u_2[i]
+                + dis_v_2
+                + b * factor_ppc[i]
+                + ((2.0 * self.0[i] as f32) - qvector_sum) * factor_ip[i] * k;
+            let err = factor_err[i] * dis_v_2.sqrt();
+            (rough, err)
+        })
+    }
+}
+
+impl
+    Accessor2<
+        [u8; 16],
+        [u8; 16],
+        (&[f32; 32], &[f32; 32], &[f32; 32], &[f32; 32]),
+        (f32, f32, f32, f32),
+    > for BlockAccessor<Dot>
+{
+    type Output = [(f32, f32); 32];
+
+    fn push(&mut self, input: &[[u8; 16]], target: &[[u8; 16]]) {
+        let t = simd::fast_scan::scan(input, target);
+        for i in 0..32 {
+            self.0[i] += t[i];
+        }
+    }
+
+    fn finish(
+        self,
+        (_, factor_ppc, factor_ip, factor_err): (&[f32; 32], &[f32; 32], &[f32; 32], &[f32; 32]),
+        (dis_v_2, b, k, qvector_sum): (f32, f32, f32, f32),
+    ) -> Self::Output {
+        std::array::from_fn(|i| {
+            let rough = 0.5 * b * factor_ppc[i]
+                + 0.5 * ((2.0 * self.0[i] as f32) - qvector_sum) * factor_ip[i] * k;
+            let err = 0.5 * factor_err[i] * dis_v_2.sqrt();
+            (rough, err)
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct DistanceAccessor<V, D>(f32, PhantomData<fn(V) -> V>, PhantomData<fn(D) -> D>);
+
+impl<V, D> Default for DistanceAccessor<V, D> {
+    fn default() -> Self {
+        Self(0.0, PhantomData, PhantomData)
+    }
+}
+
+impl Accessor2<f32, f32, (), ()> for DistanceAccessor<VectOwned<f32>, L2> {
+    type Output = Distance;
+
+    fn push(&mut self, target: &[f32], input: &[f32]) {
+        self.0 += f32::reduce_sum_of_d2(target, input)
+    }
+
+    fn finish(self, (): (), (): ()) -> Self::Output {
+        Distance::from_f32(self.0)
+    }
+}
+
+impl Accessor2<f32, f32, (), ()> for DistanceAccessor<VectOwned<f32>, Dot> {
+    type Output = Distance;
+
+    fn push(&mut self, target: &[f32], input: &[f32]) {
+        self.0 += f32::reduce_sum_of_xy(target, input)
+    }
+
+    fn finish(self, (): (), (): ()) -> Self::Output {
+        Distance::from_f32(-self.0)
+    }
+}
+
+impl Accessor2<f16, f16, (), ()> for DistanceAccessor<VectOwned<f16>, L2> {
+    type Output = Distance;
+
+    fn push(&mut self, target: &[f16], input: &[f16]) {
+        self.0 += f16::reduce_sum_of_d2(target, input)
+    }
+
+    fn finish(self, (): (), (): ()) -> Self::Output {
+        Distance::from_f32(self.0)
+    }
+}
+
+impl Accessor2<f16, f16, (), ()> for DistanceAccessor<VectOwned<f16>, Dot> {
+    type Output = Distance;
+
+    fn push(&mut self, target: &[f16], input: &[f16]) {
+        self.0 += f16::reduce_sum_of_xy(target, input)
+    }
+
+    fn finish(self, (): (), (): ()) -> Self::Output {
+        Distance::from_f32(-self.0)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ResidualAccessor<V: Vector>(Vec<V::Element>);
+
+impl<V: Vector> Default for ResidualAccessor<V> {
+    fn default() -> Self {
+        Self(Vec::new())
+    }
+}
+
+impl Accessor2<f32, f32, (), ()> for ResidualAccessor<VectOwned<f32>> {
+    type Output = VectOwned<f32>;
+
+    fn push(&mut self, target: &[f32], input: &[f32]) {
+        self.0.extend(f32::vector_sub(target, input));
+    }
+
+    fn finish(self, (): (), (): ()) -> Self::Output {
+        VectOwned::new(self.0)
+    }
+}
+
+impl Accessor2<f16, f16, (), ()> for ResidualAccessor<VectOwned<f16>> {
+    type Output = VectOwned<f16>;
+
+    fn push(&mut self, target: &[f16], input: &[f16]) {
+        self.0.extend(f16::vector_sub(target, input));
+    }
+
+    fn finish(self, (): (), (): ()) -> Self::Output {
+        VectOwned::new(self.0)
+    }
+}
+
 pub trait Vector: VectorOwned {
     type Element: Debug + Copy + FromBytes + IntoBytes + Immutable + KnownLayout;
+
     type Metadata: Debug + Copy + FromBytes + IntoBytes + Immutable + KnownLayout;
 
-    fn vector_split(vector: Self::Borrowed<'_>) -> (Self::Metadata, Vec<&[Self::Element]>);
-    fn elements_and_metadata(vector: Self::Borrowed<'_>) -> (&[Self::Element], Self::Metadata);
-    fn from_owned(vector: OwnedVector) -> Self;
+    fn split(vector: Self::Borrowed<'_>) -> (Vec<&[Self::Element]>, Self::Metadata);
 
-    fn compute_lut_block(vector: Self::Borrowed<'_>) -> BlockLut;
+    fn unpack(vector: Self::Borrowed<'_>) -> (&[Self::Element], Self::Metadata);
 
-    fn compute_lut(vector: Self::Borrowed<'_>) -> (BlockLut, BinaryLut);
+    fn block_preprocess(vector: Self::Borrowed<'_>) -> BlockLut;
+
+    fn preprocess(vector: Self::Borrowed<'_>) -> (BlockLut, BinaryLut);
 
     fn code(vector: Self::Borrowed<'_>) -> rabitq::Code;
 }
@@ -397,35 +373,28 @@ impl Vector for VectOwned<f32> {
 
     type Element = f32;
 
-    fn vector_split(vector: Self::Borrowed<'_>) -> ((), Vec<&[f32]>) {
+    fn split(vector: Self::Borrowed<'_>) -> (Vec<&[f32]>, ()) {
         let vector = vector.slice();
         (
-            (),
             match vector.len() {
                 0..=960 => vec![vector],
                 961..=1280 => vec![&vector[..640], &vector[640..]],
                 1281.. => vector.chunks(1920).collect(),
             },
+            (),
         )
     }
 
-    fn elements_and_metadata(vector: Self::Borrowed<'_>) -> (&[Self::Element], Self::Metadata) {
+    fn unpack(vector: Self::Borrowed<'_>) -> (&[Self::Element], Self::Metadata) {
         (vector.slice(), ())
     }
 
-    fn from_owned(vector: OwnedVector) -> Self {
-        match vector {
-            OwnedVector::Vecf32(x) => x,
-            _ => panic!("internal error: should be a vector"),
-        }
-    }
-
-    fn compute_lut_block(vector: Self::Borrowed<'_>) -> BlockLut {
+    fn block_preprocess(vector: Self::Borrowed<'_>) -> BlockLut {
         rabitq::block::preprocess(vector.slice())
     }
 
-    fn compute_lut(vector: Self::Borrowed<'_>) -> (BlockLut, BinaryLut) {
-        rabitq::compute_lut(vector.slice())
+    fn preprocess(vector: Self::Borrowed<'_>) -> (BlockLut, BinaryLut) {
+        rabitq::preprocess(vector.slice())
     }
 
     fn code(vector: Self::Borrowed<'_>) -> rabitq::Code {
@@ -438,35 +407,28 @@ impl Vector for VectOwned<f16> {
 
     type Element = f16;
 
-    fn vector_split(vector: Self::Borrowed<'_>) -> ((), Vec<&[f16]>) {
+    fn split(vector: Self::Borrowed<'_>) -> (Vec<&[f16]>, ()) {
         let vector = vector.slice();
         (
-            (),
             match vector.len() {
                 0..=1920 => vec![vector],
                 1921..=2560 => vec![&vector[..1280], &vector[1280..]],
                 2561.. => vector.chunks(3840).collect(),
             },
+            (),
         )
     }
 
-    fn elements_and_metadata(vector: Self::Borrowed<'_>) -> (&[Self::Element], Self::Metadata) {
+    fn unpack(vector: Self::Borrowed<'_>) -> (&[Self::Element], Self::Metadata) {
         (vector.slice(), ())
     }
 
-    fn from_owned(vector: OwnedVector) -> Self {
-        match vector {
-            OwnedVector::Vecf16(x) => x,
-            _ => panic!("internal error: should be a halfvec"),
-        }
-    }
-
-    fn compute_lut_block(vector: Self::Borrowed<'_>) -> BlockLut {
+    fn block_preprocess(vector: Self::Borrowed<'_>) -> BlockLut {
         rabitq::block::preprocess(&f16::vector_to_f32(vector.slice()))
     }
 
-    fn compute_lut(vector: Self::Borrowed<'_>) -> (BlockLut, BinaryLut) {
-        rabitq::compute_lut(&f16::vector_to_f32(vector.slice()))
+    fn preprocess(vector: Self::Borrowed<'_>) -> (BlockLut, BinaryLut) {
+        rabitq::preprocess(&f16::vector_to_f32(vector.slice()))
     }
 
     fn code(vector: Self::Borrowed<'_>) -> rabitq::Code {
@@ -474,54 +436,23 @@ impl Vector for VectOwned<f16> {
     }
 }
 
-pub trait OperatorDistance: 'static + Debug + Copy {
-    const KIND: DistanceKind;
-
-    fn compute_lowerbound_binary(lut: &BinaryLut, code: BinaryCode<'_>, epsilon: f32) -> Distance;
-
-    type BlockAccessor: for<'a> Accessor2<
-            [u8; 16],
-            [u8; 16],
-            (&'a [f32; 32], &'a [f32; 32], &'a [f32; 32], &'a [f32; 32]),
-            ((f32, f32, f32, f32), f32),
-            Output = [Distance; 32],
-        > + Default;
-
-    fn block_accessor() -> Self::BlockAccessor {
-        Default::default()
-    }
-}
-
 #[derive(Debug, Clone, Copy)]
 pub struct L2;
-
-impl OperatorDistance for L2 {
-    const KIND: DistanceKind = DistanceKind::L2;
-
-    fn compute_lowerbound_binary(lut: &BinaryLut, code: BinaryCode<'_>, epsilon: f32) -> Distance {
-        rabitq::binary::process_lowerbound_l2(lut, code, epsilon)
-    }
-
-    type BlockAccessor = Block<L2>;
-}
 
 #[derive(Debug, Clone, Copy)]
 pub struct Dot;
 
-impl OperatorDistance for Dot {
-    const KIND: DistanceKind = DistanceKind::Dot;
-
-    fn compute_lowerbound_binary(lut: &BinaryLut, code: BinaryCode<'_>, epsilon: f32) -> Distance {
-        rabitq::binary::process_lowerbound_dot(lut, code, epsilon)
-    }
-
-    type BlockAccessor = Block<Dot>;
-}
-
 pub trait Operator: 'static + Debug + Copy {
     type Vector: Vector;
 
-    type Distance: OperatorDistance;
+    type BlockAccessor: Default
+        + for<'a> Accessor2<
+            [u8; 16],
+            [u8; 16],
+            (&'a [f32; 32], &'a [f32; 32], &'a [f32; 32], &'a [f32; 32]),
+            (f32, f32, f32, f32),
+            Output = [(f32, f32); 32],
+        >;
 
     type DistanceAccessor: Default
         + Accessor2<
@@ -532,8 +463,6 @@ pub trait Operator: 'static + Debug + Copy {
             Output = Distance,
         >;
 
-    const SUPPORTS_RESIDUAL: bool;
-
     type ResidualAccessor: Default
         + Accessor2<
             <Self::Vector as Vector>::Element,
@@ -542,6 +471,10 @@ pub trait Operator: 'static + Debug + Copy {
             <Self::Vector as Vector>::Metadata,
             Output = Self::Vector,
         >;
+
+    const SUPPORTS_RESIDUAL: bool;
+
+    fn binary_process(lut: &BinaryLut, code: BinaryCode<'_>) -> (f32, f32);
 }
 
 #[derive(Debug)]
@@ -558,47 +491,63 @@ impl<V, D> Copy for Op<V, D> {}
 impl Operator for Op<VectOwned<f32>, L2> {
     type Vector = VectOwned<f32>;
 
-    type Distance = L2;
+    type BlockAccessor = BlockAccessor<L2>;
 
-    type DistanceAccessor = Sum<Op<VectOwned<f32>, L2>>;
+    type DistanceAccessor = DistanceAccessor<VectOwned<f32>, L2>;
+
+    type ResidualAccessor = ResidualAccessor<VectOwned<f32>>;
 
     const SUPPORTS_RESIDUAL: bool = true;
 
-    type ResidualAccessor = Diff<Op<VectOwned<f32>, L2>>;
+    fn binary_process(lut: &BinaryLut, code: BinaryCode<'_>) -> (f32, f32) {
+        rabitq::binary::process_l2(lut, code)
+    }
 }
 
 impl Operator for Op<VectOwned<f32>, Dot> {
     type Vector = VectOwned<f32>;
 
-    type Distance = Dot;
+    type BlockAccessor = BlockAccessor<Dot>;
 
-    type DistanceAccessor = Sum<Op<VectOwned<f32>, Dot>>;
+    type DistanceAccessor = DistanceAccessor<VectOwned<f32>, Dot>;
+
+    type ResidualAccessor = ResidualAccessor<VectOwned<f32>>;
 
     const SUPPORTS_RESIDUAL: bool = false;
 
-    type ResidualAccessor = Diff<Op<VectOwned<f32>, Dot>>;
+    fn binary_process(lut: &BinaryLut, code: BinaryCode<'_>) -> (f32, f32) {
+        rabitq::binary::process_dot(lut, code)
+    }
 }
 
 impl Operator for Op<VectOwned<f16>, L2> {
     type Vector = VectOwned<f16>;
 
-    type Distance = L2;
+    type BlockAccessor = BlockAccessor<L2>;
 
-    type DistanceAccessor = Sum<Op<VectOwned<f16>, L2>>;
+    type DistanceAccessor = DistanceAccessor<VectOwned<f16>, L2>;
+
+    type ResidualAccessor = ResidualAccessor<VectOwned<f16>>;
 
     const SUPPORTS_RESIDUAL: bool = true;
 
-    type ResidualAccessor = Diff<Op<VectOwned<f16>, L2>>;
+    fn binary_process(lut: &BinaryLut, code: BinaryCode<'_>) -> (f32, f32) {
+        rabitq::binary::process_l2(lut, code)
+    }
 }
 
 impl Operator for Op<VectOwned<f16>, Dot> {
     type Vector = VectOwned<f16>;
 
-    type Distance = Dot;
+    type BlockAccessor = BlockAccessor<Dot>;
 
-    type DistanceAccessor = Sum<Op<VectOwned<f16>, Dot>>;
+    type DistanceAccessor = DistanceAccessor<VectOwned<f16>, Dot>;
+
+    type ResidualAccessor = ResidualAccessor<VectOwned<f16>>;
 
     const SUPPORTS_RESIDUAL: bool = false;
 
-    type ResidualAccessor = Diff<Op<VectOwned<f16>, Dot>>;
+    fn binary_process(lut: &BinaryLut, code: BinaryCode<'_>) -> (f32, f32) {
+        rabitq::binary::process_dot(lut, code)
+    }
 }

--- a/crates/algorithm/src/tuples.rs
+++ b/crates/algorithm/src/tuples.rs
@@ -2,7 +2,7 @@ use crate::IndexPointer;
 use crate::operator::Vector;
 use rabitq::binary::BinaryCode;
 use std::marker::PhantomData;
-use std::num::{NonZeroU8, NonZeroU64};
+use std::num::NonZero;
 use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout};
 
 pub const ALIGN: usize = 8;
@@ -204,7 +204,7 @@ impl FreepageTupleWriter<'_> {
 #[repr(C, align(8))]
 #[derive(Debug, Clone, PartialEq, FromBytes, IntoBytes, Immutable, KnownLayout)]
 struct VectorTupleHeader0 {
-    payload: Option<NonZeroU64>,
+    payload: Option<NonZero<u64>>,
     metadata_s: usize,
     elements_s: usize,
     elements_e: usize,
@@ -215,7 +215,7 @@ struct VectorTupleHeader0 {
 #[repr(C, align(8))]
 #[derive(Debug, Clone, PartialEq, FromBytes, IntoBytes, Immutable, KnownLayout)]
 struct VectorTupleHeader1 {
-    payload: Option<NonZeroU64>,
+    payload: Option<NonZero<u64>>,
     pointer: IndexPointer,
     elements_s: usize,
     elements_e: usize,
@@ -224,12 +224,12 @@ struct VectorTupleHeader1 {
 #[derive(Debug, Clone, PartialEq)]
 pub enum VectorTuple<V: Vector> {
     _0 {
-        payload: Option<NonZeroU64>,
+        payload: Option<NonZero<u64>>,
         metadata: V::Metadata,
         elements: Vec<V::Element>,
     },
     _1 {
-        payload: Option<NonZeroU64>,
+        payload: Option<NonZero<u64>>,
         pointer: IndexPointer,
         elements: Vec<V::Element>,
     },
@@ -351,7 +351,7 @@ pub enum VectorTupleReader<'a, V: Vector> {
 impl<V: Vector> Copy for VectorTupleReader<'_, V> {}
 
 impl<'a, V: Vector> VectorTupleReader<'a, V> {
-    pub fn payload(self) -> Option<NonZeroU64> {
+    pub fn payload(self) -> Option<NonZero<u64>> {
         match self {
             VectorTupleReader::_0(this) => this.header.payload,
             VectorTupleReader::_1(this) => this.header.payload,
@@ -642,7 +642,7 @@ struct FrozenTupleHeader0 {
     factor_ppc: [f32; 32],
     factor_ip: [f32; 32],
     factor_err: [f32; 32],
-    payload: [Option<NonZeroU64>; 32],
+    payload: [Option<NonZero<u64>>; 32],
     elements_s: usize,
     elements_e: usize,
 }
@@ -663,7 +663,7 @@ pub enum FrozenTuple {
         factor_ppc: [f32; 32],
         factor_ip: [f32; 32],
         factor_err: [f32; 32],
-        payload: [Option<NonZeroU64>; 32],
+        payload: [Option<NonZero<u64>>; 32],
         elements: Vec<[u8; 16]>,
     },
     _1 {
@@ -815,7 +815,7 @@ impl<'a> FrozenTupleReader0<'a> {
     pub fn elements(self) -> &'a [[u8; 16]] {
         self.elements
     }
-    pub fn payload(self) -> &'a [Option<NonZeroU64>; 32] {
+    pub fn payload(self) -> &'a [Option<NonZero<u64>>; 32] {
         &self.header.payload
     }
 }
@@ -855,7 +855,7 @@ pub struct FrozenTupleWriter1<'a> {
 }
 
 impl FrozenTupleWriter0<'_> {
-    pub fn payload(&mut self) -> &mut [Option<NonZeroU64>; 32] {
+    pub fn payload(&mut self) -> &mut [Option<NonZero<u64>>; 32] {
         &mut self.header.payload
     }
 }
@@ -868,7 +868,7 @@ struct AppendableTupleHeader {
     factor_ppc: f32,
     factor_ip: f32,
     factor_err: f32,
-    payload: Option<NonZeroU64>,
+    payload: Option<NonZero<u64>>,
     elements_s: usize,
     elements_e: usize,
 }
@@ -880,7 +880,7 @@ pub struct AppendableTuple {
     pub factor_ppc: f32,
     pub factor_ip: f32,
     pub factor_err: f32,
-    pub payload: Option<NonZeroU64>,
+    pub payload: Option<NonZero<u64>>,
     pub elements: Vec<u64>,
 }
 
@@ -949,7 +949,7 @@ impl<'a> AppendableTupleReader<'a> {
             self.elements,
         )
     }
-    pub fn payload(self) -> Option<NonZeroU64> {
+    pub fn payload(self) -> Option<NonZero<u64>> {
         self.header.payload
     }
 }
@@ -962,7 +962,7 @@ pub struct AppendableTupleWriter<'a> {
 }
 
 impl AppendableTupleWriter<'_> {
-    pub fn payload(&mut self) -> &mut Option<NonZeroU64> {
+    pub fn payload(&mut self) -> &mut Option<NonZero<u64>> {
         &mut self.header.payload
     }
 }
@@ -1004,7 +1004,7 @@ const fn soundness_check() {
     Immutable,
     KnownLayout,
 )]
-pub struct ZeroU8(Option<NonZeroU8>);
+pub struct ZeroU8(Option<NonZero<u8>>);
 
 #[repr(transparent)]
 #[derive(

--- a/crates/algorithm/src/vectors.rs
+++ b/crates/algorithm/src/vectors.rs
@@ -1,7 +1,7 @@
 use crate::operator::*;
 use crate::tuples::*;
 use crate::{IndexPointer, Page, PageGuard, RelationRead, RelationWrite, tape};
-use std::num::NonZeroU64;
+use std::num::NonZero;
 use vector::VectorOwned;
 
 pub fn read_for_h1_tuple<
@@ -33,7 +33,7 @@ pub fn read_for_h0_tuple<
 >(
     index: impl RelationRead,
     mean: IndexPointer,
-    payload: NonZeroU64,
+    payload: NonZero<u64>,
     accessor: A,
 ) -> Option<A::Output> {
     let mut cursor = Err(mean);
@@ -58,7 +58,7 @@ pub fn append<O: Operator>(
     index: impl RelationWrite,
     vectors_first: u32,
     vector: <O::Vector as VectorOwned>::Borrowed<'_>,
-    payload: NonZeroU64,
+    payload: NonZero<u64>,
 ) -> IndexPointer {
     fn append(index: impl RelationWrite, first: u32, bytes: &[u8]) -> IndexPointer {
         if let Some(mut write) = index.search(bytes.len()) {
@@ -69,7 +69,7 @@ pub fn append<O: Operator>(
         }
         tape::append(index, first, bytes, true)
     }
-    let (metadata, slices) = O::Vector::vector_split(vector);
+    let (slices, metadata) = O::Vector::split(vector);
     let mut chain = Ok(metadata);
     for i in (0..slices.len()).rev() {
         let bytes = VectorTuple::<O::Vector>::serialize(&match chain {

--- a/crates/k_means/src/lib.rs
+++ b/crates/k_means/src/lib.rs
@@ -164,10 +164,10 @@ fn rabitq_index(
             let lut = rabitq::block::preprocess(&samples[i]);
             let mut result = (f32::INFINITY, 0);
             for block in 0..c.div_ceil(32) {
-                let lowerbound =
-                    rabitq::block::process_lowerbound_l2(&lut, blocks[block].code(), 1.9);
+                let returns = rabitq::block::process_l2(&lut, blocks[block].code());
+                let lowerbound = returns.map(|(rough, err)| rough - err * 1.9);
                 for j in block * 32..std::cmp::min(block * 32 + 32, c) {
-                    if lowerbound[j - block * 32].to_f32() < result.0 {
+                    if lowerbound[j - block * 32] < result.0 {
                         let dis = f32::reduce_sum_of_d2(&samples[i], &centroids[j]);
                         if dis <= result.0 {
                             result = (dis, j);

--- a/crates/rabitq/src/binary.rs
+++ b/crates/rabitq/src/binary.rs
@@ -1,4 +1,3 @@
-use distance::Distance;
 use simd::Floating;
 
 pub type BinaryLut = (
@@ -18,32 +17,30 @@ pub fn preprocess(vector: &[f32]) -> BinaryLut {
     ((dis_v_2, b, k, qvector_sum), binarize(&qvector))
 }
 
-pub fn process_lowerbound_l2(
+pub fn process_l2(
     lut: &BinaryLut,
     (dis_u_2, factor_ppc, factor_ip, factor_err, t): BinaryCode<'_>,
-    epsilon: f32,
-) -> Distance {
+) -> (f32, f32) {
     let &((dis_v_2, b, k, qvector_sum), ref s) = lut;
     let value = asymmetric_binary_dot_product(t, s) as u16;
     let rough =
         dis_u_2 + dis_v_2 + b * factor_ppc + ((2.0 * value as f32) - qvector_sum) * factor_ip * k;
     let err = factor_err * dis_v_2.sqrt();
-    Distance::from_f32(rough - epsilon * err)
+    (rough, err)
 }
 
-pub fn process_lowerbound_dot(
+pub fn process_dot(
     lut: &BinaryLut,
     (_, factor_ppc, factor_ip, factor_err, t): BinaryCode<'_>,
-    epsilon: f32,
-) -> Distance {
+) -> (f32, f32) {
     let &((dis_v_2, b, k, qvector_sum), ref s) = lut;
     let value = asymmetric_binary_dot_product(t, s) as u16;
     let rough = 0.5 * b * factor_ppc + 0.5 * ((2.0 * value as f32) - qvector_sum) * factor_ip * k;
     let err = 0.5 * factor_err * dis_v_2.sqrt();
-    Distance::from_f32(rough - epsilon * err)
+    (rough, err)
 }
 
-pub fn binarize(vector: &[u8]) -> (Vec<u64>, Vec<u64>, Vec<u64>, Vec<u64>) {
+pub(crate) fn binarize(vector: &[u8]) -> (Vec<u64>, Vec<u64>, Vec<u64>, Vec<u64>) {
     let n = vector.len();
     let mut t0 = vec![0u64; n.div_ceil(64)];
     let mut t1 = vec![0u64; n.div_ceil(64)];
@@ -58,7 +55,10 @@ pub fn binarize(vector: &[u8]) -> (Vec<u64>, Vec<u64>, Vec<u64>, Vec<u64>) {
     (t0, t1, t2, t3)
 }
 
-fn asymmetric_binary_dot_product(x: &[u64], y: &(Vec<u64>, Vec<u64>, Vec<u64>, Vec<u64>)) -> u32 {
+pub(crate) fn asymmetric_binary_dot_product(
+    x: &[u64],
+    y: &(Vec<u64>, Vec<u64>, Vec<u64>, Vec<u64>),
+) -> u32 {
     let t0 = simd::bit::sum_of_and(x, &y.0);
     let t1 = simd::bit::sum_of_and(x, &y.1);
     let t2 = simd::bit::sum_of_and(x, &y.2);

--- a/crates/rabitq/src/lib.rs
+++ b/crates/rabitq/src/lib.rs
@@ -74,7 +74,7 @@ pub fn code(dims: u32, vector: &[f32]) -> Code {
     }
 }
 
-pub fn compute_lut(vector: &[f32]) -> (BlockLut, BinaryLut) {
+pub fn preprocess(vector: &[f32]) -> (BlockLut, BinaryLut) {
     use simd::Floating;
     let dis_v_2 = f32::reduce_sum_of_x2(vector);
     let (k, b, qvector) = simd::quantize::quantize(vector, 15.0);

--- a/src/datatype/typmod.rs
+++ b/src/datatype/typmod.rs
@@ -1,11 +1,11 @@
 use serde::{Deserialize, Serialize};
 use std::ffi::{CStr, CString};
-use std::num::{NonZero, NonZeroU32};
+use std::num::NonZero;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum Typmod {
     Any,
-    Dims(NonZeroU32),
+    Dims(NonZero<u32>),
 }
 
 impl Typmod {
@@ -14,7 +14,7 @@ impl Typmod {
         if x == -1 {
             Some(Any)
         } else if x >= 1 {
-            Some(Dims(NonZeroU32::new(x as u32).unwrap()))
+            Some(Dims(NonZero::new(x as u32).unwrap()))
         } else {
             None
         }
@@ -33,7 +33,7 @@ impl Typmod {
             Dims(x) => x.get() as i32,
         }
     }
-    pub fn dims(self) -> Option<NonZeroU32> {
+    pub fn dims(self) -> Option<NonZero<u32>> {
         use Typmod::*;
         match self {
             Any => None,

--- a/src/index/algorithm.rs
+++ b/src/index/algorithm.rs
@@ -4,7 +4,7 @@ use algorithm::operator::{Dot, L2, Op};
 use algorithm::types::*;
 use algorithm::{RelationRead, RelationWrite};
 use half::f16;
-use std::num::NonZeroU64;
+use std::num::NonZero;
 use vector::VectorOwned;
 use vector::vect::{VectBorrowed, VectOwned};
 
@@ -38,7 +38,7 @@ pub fn bulkdelete(
     opfamily: Opfamily,
     index: impl RelationWrite,
     check: impl Fn(),
-    callback: impl Fn(NonZeroU64) -> bool,
+    callback: impl Fn(NonZero<u64>) -> bool,
 ) {
     match (opfamily.vector_kind(), opfamily.distance_kind()) {
         (VectorKind::Vecf32, DistanceKind::L2) => {
@@ -110,7 +110,7 @@ pub fn build(
 pub fn insert(
     opfamily: Opfamily,
     index: impl RelationWrite,
-    payload: NonZeroU64,
+    payload: NonZero<u64>,
     vector: OwnedVector,
 ) {
     match (vector, opfamily.distance_kind()) {

--- a/src/index/am/am_build.rs
+++ b/src/index/am/am_build.rs
@@ -1,5 +1,5 @@
 use crate::datatype::typmod::Typmod;
-use crate::index::am::{Reloption, ctid_to_pointer};
+use crate::index::am::{Reloption, ctid_to_key, kv_to_pointer};
 use crate::index::opclass::{Opfamily, opfamily};
 use crate::index::storage::{PostgresPage, PostgresRelation};
 use crate::index::types::*;
@@ -383,7 +383,8 @@ pub unsafe extern "C" fn ambuild(
         let relation = unsafe { PostgresRelation::new(index_relation) };
         heap.traverse(true, |(ctid, store)| {
             for (vector, extra) in store {
-                let payload = ctid_to_pointer(ctid, extra);
+                let key = ctid_to_key(ctid);
+                let payload = kv_to_pointer((key, extra));
                 crate::index::algorithm::insert(opfamily, relation.clone(), payload, vector);
             }
             indtuples += 1;
@@ -864,7 +865,8 @@ unsafe fn parallel_build(
         VchordrqCachedReader::_0(_) => {
             heap.traverse(true, |(ctid, store)| {
                 for (vector, extra) in store {
-                    let payload = ctid_to_pointer(ctid, extra);
+                    let key = ctid_to_key(ctid);
+                    let payload = kv_to_pointer((key, extra));
                     crate::index::algorithm::insert(opfamily, index.clone(), payload, vector);
                 }
                 unsafe {
@@ -886,7 +888,8 @@ unsafe fn parallel_build(
             };
             heap.traverse(true, |(ctid, store)| {
                 for (vector, extra) in store {
-                    let payload = ctid_to_pointer(ctid, extra);
+                    let key = ctid_to_key(ctid);
+                    let payload = kv_to_pointer((key, extra));
                     crate::index::algorithm::insert(opfamily, index.clone(), payload, vector);
                 }
                 unsafe {

--- a/src/index/scanners/maxsim.rs
+++ b/src/index/scanners/maxsim.rs
@@ -1,16 +1,15 @@
 use super::{SearchBuilder, SearchFetcher, SearchOptions};
 use crate::index::algorithm::RandomProject;
-use crate::index::am::pointer_to_ctid;
+use crate::index::am::pointer_to_kv;
 use crate::index::opclass::Opfamily;
-use algorithm::operator::{Dot, Op, Vector};
+use algorithm::operator::Dot;
 use algorithm::types::{DistanceKind, OwnedVector, VectorKind};
 use algorithm::{RelationRead, RerankMethod};
 use always_equal::AlwaysEqual;
 use distance::Distance;
 use half::f16;
-use pgrx::pg_sys::{BlockIdData, ItemPointerData};
 use std::cmp::Reverse;
-use std::collections::{BinaryHeap, HashMap};
+use std::collections::BinaryHeap;
 use vector::VectorOwned;
 use vector::vect::VectOwned;
 
@@ -46,7 +45,7 @@ impl SearchBuilder for MaxsimBuilder {
         relation: impl RelationRead + 'a,
         options: SearchOptions,
         _: impl SearchFetcher + 'a,
-    ) -> Box<dyn Iterator<Item = (f32, ItemPointerData, bool)> + 'a> {
+    ) -> Box<dyn Iterator<Item = (f32, [u16; 3], bool)> + 'a> {
         let mut vectors = None;
         for orderby_vectors in self.orderbys.into_iter().flatten() {
             if vectors.is_none() {
@@ -58,179 +57,190 @@ impl SearchBuilder for MaxsimBuilder {
         if let Some(_max_scan_tuples) = options.max_scan_tuples {
             pgrx::error!("maxsim search with max_scan_tuples is not supported");
         }
-        let max_maxsim_tuples = options
-            .max_maxsim_tuples
-            .expect("max_maxsim_tuples must be set for maxsim search");
+        let maxsim_refine = options.maxsim_refine;
         let maxsim_threshold = options.maxsim_threshold;
         let opfamily = self.opfamily;
         let Some(vectors) = vectors else {
-            return Box::new(std::iter::empty())
-                as Box<dyn Iterator<Item = (f32, ItemPointerData, bool)>>;
+            return Box::new(std::iter::empty()) as Box<dyn Iterator<Item = (f32, [u16; 3], bool)>>;
         };
         let method = algorithm::how(relation.clone());
         if !matches!(method, RerankMethod::Index) {
             pgrx::error!("maxsim search with rerank_in_table is not supported");
         }
         assert!(matches!(opfamily.distance_kind(), DistanceKind::Dot));
-        let (c, estimations) = match opfamily.vector_kind() {
+        let n = vectors.len();
+        let accu_map = |(Reverse(dis), AlwaysEqual(pay))| (dis, pay);
+        let rough_map = |(_, AlwaysEqual(dis), AlwaysEqual(pay), _)| (dis, pay);
+        let iter: Box<dyn Iterator<Item = _>> = match opfamily.vector_kind() {
             VectorKind::Vecf32 => {
+                type Op = algorithm::operator::Op<VectOwned<f32>, Dot>;
                 let vectors = vectors
                     .into_iter()
                     .map(|vector| {
                         RandomProject::project(
-                            VectOwned::<f32>::from_owned(vector.clone()).as_borrowed(),
+                            if let OwnedVector::Vecf32(vector) = vector {
+                                vector
+                            } else {
+                                unreachable!()
+                            }
+                            .as_borrowed(),
                         )
                     })
                     .collect::<Vec<_>>();
-                let mut estimations = Vec::new();
-                let mut c = HashMap::<[u16; 3], States>::new();
-                for (query_id, vector) in vectors.iter().enumerate() {
-                    let (results, est) = algorithm::search_and_estimate::<Op<VectOwned<f32>, Dot>>(
+                Box::new(vectors.into_iter().map(|vector| {
+                    let (results, estimation) = algorithm::maxsim_search::<Op>(
                         relation.clone(),
                         vector.clone(),
                         options.probes.clone(),
                         options.epsilon,
                         maxsim_threshold,
                     );
-                    if results.is_empty() {
-                        estimations.push(0.0);
-                        continue;
-                    }
-                    let returning = if options.epsilon == 0.0 && options.allows_skipping_rerank {
-                        algorithm::skip(results)
-                            .take(max_maxsim_tuples as usize)
-                            .collect::<Vec<_>>()
-                    } else {
-                        algorithm::rerank_index::<Op<VectOwned<f32>, Dot>>(
+                    let (mut accu_set, mut rough_set) = (Vec::new(), Vec::new());
+                    if maxsim_refine != 0 && !results.is_empty() {
+                        let mut reranker = algorithm::rerank_index::<Op, _>(
                             relation.clone(),
                             vector.clone(),
                             results,
-                        )
-                        .take(max_maxsim_tuples as usize)
-                        .collect::<Vec<_>>()
-                    };
-                    let mut max = f32::NEG_INFINITY;
-                    for (distance, payload) in returning {
-                        max = max.max(distance.to_f32());
-                        use std::collections::hash_map::Entry::{Occupied, Vacant};
-                        let (ctid, _) = pointer_to_ctid(payload);
-                        let key = [ctid.ip_blkid.bi_hi, ctid.ip_blkid.bi_lo, ctid.ip_posid];
-                        match c.entry(key) {
-                            Vacant(e) => {
-                                let states = e.insert(States::new(vectors.len()));
-                                states.update(query_id, distance);
-                            }
-                            Occupied(mut e) => {
-                                let states = e.get_mut();
-                                states.update(query_id, distance);
-                            }
-                        }
+                        );
+                        accu_set.extend(reranker.by_ref().take(maxsim_refine as _));
+                        let (rough_iter, accu_iter) = reranker.finish();
+                        accu_set.extend(accu_iter.map(accu_map));
+                        rough_set.extend(rough_iter.map(rough_map));
+                    } else {
+                        let rough_iter = results.into_iter();
+                        rough_set.extend(rough_iter.map(rough_map));
                     }
-                    estimations.push(max.max(est.to_f32()));
-                }
-                (c, estimations)
+                    (accu_set, rough_set, estimation)
+                }))
             }
             VectorKind::Vecf16 => {
+                type Op = algorithm::operator::Op<VectOwned<f16>, Dot>;
                 let vectors = vectors
                     .into_iter()
                     .map(|vector| {
                         RandomProject::project(
-                            VectOwned::<f16>::from_owned(vector.clone()).as_borrowed(),
+                            if let OwnedVector::Vecf16(vector) = vector {
+                                vector
+                            } else {
+                                unreachable!()
+                            }
+                            .as_borrowed(),
                         )
                     })
                     .collect::<Vec<_>>();
-                let mut estimations = Vec::new();
-                let mut c = HashMap::<[u16; 3], States>::new();
-                for (query_id, vector) in vectors.iter().enumerate() {
-                    let (results, est) = algorithm::search_and_estimate::<Op<VectOwned<f16>, Dot>>(
+                Box::new(vectors.into_iter().map(|vector| {
+                    let (results, estimation) = algorithm::maxsim_search::<Op>(
                         relation.clone(),
                         vector.clone(),
                         options.probes.clone(),
                         options.epsilon,
                         maxsim_threshold,
                     );
-                    if results.is_empty() {
-                        estimations.push(0.0);
-                        continue;
-                    }
-                    let returning = if options.epsilon == 0.0 && options.allows_skipping_rerank {
-                        algorithm::skip(results)
-                            .take(max_maxsim_tuples as usize)
-                            .collect::<Vec<_>>()
-                    } else {
-                        algorithm::rerank_index::<Op<VectOwned<f16>, Dot>>(
+                    let (mut accu_set, mut rough_set) = (Vec::new(), Vec::new());
+                    if maxsim_refine != 0 && !results.is_empty() {
+                        let mut reranker = algorithm::rerank_index::<Op, _>(
                             relation.clone(),
                             vector.clone(),
                             results,
-                        )
-                        .take(max_maxsim_tuples as usize)
-                        .collect::<Vec<_>>()
-                    };
-                    let mut max = f32::NEG_INFINITY;
-                    for (distance, payload) in returning {
-                        max = max.max(distance.to_f32());
-                        use std::collections::hash_map::Entry::{Occupied, Vacant};
-                        let (ctid, _) = pointer_to_ctid(payload);
-                        let key = [ctid.ip_blkid.bi_hi, ctid.ip_blkid.bi_lo, ctid.ip_posid];
-                        match c.entry(key) {
-                            Vacant(e) => {
-                                let states = e.insert(States::new(vectors.len()));
-                                states.update(query_id, distance);
-                            }
-                            Occupied(mut e) => {
-                                let states = e.get_mut();
-                                states.update(query_id, distance);
-                            }
-                        }
+                        );
+                        accu_set.extend(reranker.by_ref().take(maxsim_refine as _));
+                        let (rough_iter, accu_iter) = reranker.finish();
+                        accu_set.extend(accu_iter.map(accu_map));
+                        rough_set.extend(rough_iter.map(rough_map));
+                    } else {
+                        let rough_iter = results.into_iter();
+                        rough_set.extend(rough_iter.map(rough_map));
                     }
-                    estimations.push(max.max(est.to_f32()));
-                }
-                (c, estimations)
+                    (accu_set, rough_set, estimation)
+                }))
             }
         };
-        let c = c
-            .into_iter()
-            .map(|(key, states)| {
+        let mut updates = Vec::new();
+        let mut estimations = Vec::new();
+        for (query_id, (accu_set, rough_set, estimation)) in iter.enumerate() {
+            updates.reserve(accu_set.len() + rough_set.len());
+            let is_empty = accu_set.is_empty() && rough_set.is_empty();
+            let mut estimation_by_accu = f32::NEG_INFINITY;
+            for (distance, payload) in accu_set {
+                estimation_by_accu = estimation_by_accu.max(distance.to_f32());
+                let (key, _) = pointer_to_kv(payload);
+                updates.push((key, AlwaysEqual((query_id, distance))));
+            }
+            for (distance, payload) in rough_set {
+                let (key, _) = pointer_to_kv(payload);
+                updates.push((key, AlwaysEqual((query_id, distance))));
+            }
+            estimations.push(if !is_empty {
+                estimation_by_accu.max(estimation.to_f32())
+            } else {
+                0.0
+            });
+        }
+        updates.sort_unstable();
+        let iter = updates
+            .chunk_by(|(x, _), (y, _)| x == y)
+            .map(|chunk| {
+                let key = chunk[0].0;
+                let mut value = vec![None; n];
+                for &(_, AlwaysEqual((query_id, distance))) in chunk {
+                    let this = value[query_id].get_or_insert(Distance::INFINITY);
+                    *this = std::cmp::min(*this, distance);
+                }
                 let mut maxsim = 0.0f32;
-                for (query_id, distance) in states.into_iter() {
+                for (query_id, distance) in value.into_iter().enumerate() {
                     let d = distance.unwrap_or(Distance::from_f32(estimations[query_id]));
-                    maxsim += opfamily.output(d);
+                    maxsim += Distance::to_f32(d);
                 }
                 (Reverse(Distance::from_f32(maxsim)), AlwaysEqual(key))
             })
-            .collect::<Vec<_>>();
-        let mut c = BinaryHeap::from(c);
-        Box::new(std::iter::from_fn(move || {
-            let (Reverse(distance), AlwaysEqual(key)) = c.pop()?;
-            let distance = distance.to_f32();
-            let ctid = ItemPointerData {
-                ip_blkid: BlockIdData {
-                    bi_hi: key[0],
-                    bi_lo: key[1],
-                },
-                ip_posid: key[2],
-            };
-            let recheck = false;
-            Some((distance, ctid, recheck))
-        }))
+            .collect::<BinaryHeap<_>>()
+            .into_iter_sorted_polyfill()
+            .map(|(Reverse(distance), AlwaysEqual(key))| {
+                let distance = distance.to_f32();
+                let recheck = false;
+                (distance, key, recheck)
+            });
+        let iter: Box<dyn Iterator<Item = _>> = Box::new(iter);
+        let iter = if let Some(max_scan_tuples) = options.max_scan_tuples {
+            Box::new(iter.take(max_scan_tuples as _))
+        } else {
+            iter
+        };
+        #[allow(clippy::let_and_return)]
+        iter
     }
 }
 
-struct States {
-    inner: Vec<Option<Distance>>,
+pub trait IntoIterSortedPolyfill<T> {
+    fn into_iter_sorted_polyfill(self) -> IntoIterSorted<T>;
 }
 
-impl States {
-    fn new(len: usize) -> Self {
-        Self {
-            inner: vec![None; len],
-        }
-    }
-    fn update(&mut self, query_id: usize, distance: Distance) {
-        let this = self.inner[query_id].get_or_insert(Distance::INFINITY);
-        *this = std::cmp::min(*this, distance);
-    }
-    fn into_iter(self) -> impl Iterator<Item = (usize, Option<Distance>)> {
-        self.inner.into_iter().enumerate()
+impl<T> IntoIterSortedPolyfill<T> for BinaryHeap<T> {
+    fn into_iter_sorted_polyfill(self) -> IntoIterSorted<T> {
+        IntoIterSorted { inner: self }
     }
 }
+
+#[derive(Clone, Debug)]
+pub struct IntoIterSorted<T> {
+    inner: BinaryHeap<T>,
+}
+
+impl<T: Ord> Iterator for IntoIterSorted<T> {
+    type Item = T;
+
+    #[inline]
+    fn next(&mut self) -> Option<T> {
+        self.inner.pop()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let exact = self.inner.len();
+        (exact, Some(exact))
+    }
+}
+
+impl<T: Ord> ExactSizeIterator for IntoIterSorted<T> {}
+
+impl<T: Ord> std::iter::FusedIterator for IntoIterSorted<T> {}

--- a/tests/logic/multivector.slt
+++ b/tests/logic/multivector.slt
@@ -21,7 +21,7 @@ statement ok
 SET vchordrq.probes = '';
 
 statement ok
-SET vchordrq.max_maxsim_tuples = 3000;
+SET vchordrq.maxsim_refine = 3000;
 
 statement ok
 SET enable_seqscan TO off;


### PR DESCRIPTION
1. rename `max_maxsim_tuples` to `maxsim_refine`; leave it a default value `0`
2. remove `allows_skipping_rerank`; use estimated distance for vectors whose distance is not calculated