### PR TITLE
fix: do not error if vector has unexpected length

### DIFF
--- a/crates/algorithm/src/operator.rs
+++ b/crates/algorithm/src/operator.rs
@@ -150,6 +150,7 @@ impl<E0, E1, M0, M1, A: Accessor2<E0, E1, M0, M1>> Accessor1<E1, M1> for LAccess
     }
 
     fn finish(self, rhs: M1) -> Self::Output {
+        assert!(!self.elements.is_empty(), "goal is shorter than expected");
         self.accessor.finish(self.metadata, rhs)
     }
 }
@@ -180,7 +181,98 @@ impl<E0, E1, M0, M1, A: Accessor2<E0, E1, M0, M1>> Accessor1<E0, M0> for RAccess
     }
 
     fn finish(self, lhs: M0) -> Self::Output {
+        assert!(!self.elements.is_empty(), "goal is shorter than expected");
         self.accessor.finish(lhs, self.metadata)
+    }
+}
+
+pub trait TryAccessor1<E, M>: Sized {
+    type Output;
+    #[must_use]
+    fn push(&mut self, input: &[E]) -> Option<()>;
+    #[must_use]
+    fn finish(self, input: M) -> Option<Self::Output>;
+}
+
+impl<E, M: Copy> TryAccessor1<E, M> for () {
+    type Output = ();
+
+    fn push(&mut self, _: &[E]) -> Option<()> {
+        Some(())
+    }
+
+    fn finish(self, _: M) -> Option<Self::Output> {
+        Some(())
+    }
+}
+
+impl<E, M: Copy, A> TryAccessor1<E, M> for (A,)
+where
+    A: TryAccessor1<E, M>,
+{
+    type Output = (A::Output,);
+
+    fn push(&mut self, input: &[E]) -> Option<()> {
+        self.0.push(input)?;
+        Some(())
+    }
+
+    fn finish(self, input: M) -> Option<Self::Output> {
+        Some((self.0.finish(input)?,))
+    }
+}
+
+impl<E, M: Copy, A, B> TryAccessor1<E, M> for (A, B)
+where
+    A: TryAccessor1<E, M>,
+    B: TryAccessor1<E, M>,
+{
+    type Output = (A::Output, B::Output);
+
+    fn push(&mut self, input: &[E]) -> Option<()> {
+        self.0.push(input)?;
+        self.1.push(input)?;
+        Some(())
+    }
+
+    fn finish(self, input: M) -> Option<Self::Output> {
+        Some((self.0.finish(input)?, self.1.finish(input)?))
+    }
+}
+
+pub struct LTryAccess<'a, E, M, A> {
+    elements: &'a [E],
+    metadata: M,
+    accessor: A,
+}
+
+impl<'a, E, M, A> LTryAccess<'a, E, M, A> {
+    pub fn new((elements, metadata): (&'a [E], M), accessor: A) -> Self {
+        Self {
+            elements,
+            metadata,
+            accessor,
+        }
+    }
+}
+
+impl<E0, E1, M0, M1, A: Accessor2<E0, E1, M0, M1>> TryAccessor1<E1, M1>
+    for LTryAccess<'_, E0, M0, A>
+{
+    type Output = A::Output;
+
+    fn push(&mut self, rhs: &[E1]) -> Option<()> {
+        let (lhs, elements) = self.elements.split_at_checked(rhs.len())?;
+        self.accessor.push(lhs, rhs);
+        self.elements = elements;
+        Some(())
+    }
+
+    fn finish(self, rhs: M1) -> Option<Self::Output> {
+        if !self.elements.is_empty() {
+            return None;
+        }
+        Some(self.accessor.finish(self.metadata, rhs))
     }
 }
 
@@ -377,7 +469,8 @@ impl Vector for VectOwned<f32> {
         let vector = vector.slice();
         (
             match vector.len() {
-                0..=960 => vec![vector],
+                0 => unreachable!(),
+                1..=960 => vec![vector],
                 961..=1280 => vec![&vector[..640], &vector[640..]],
                 1281.. => vector.chunks(1920).collect(),
             },
@@ -411,7 +504,8 @@ impl Vector for VectOwned<f16> {
         let vector = vector.slice();
         (
             match vector.len() {
-                0..=1920 => vec![vector],
+                0 => unreachable!(),
+                1..=1920 => vec![vector],
                 1921..=2560 => vec![&vector[..1280], &vector[1280..]],
                 2561.. => vector.chunks(3840).collect(),
             },

--- a/crates/algorithm/src/rerank.rs
+++ b/crates/algorithm/src/rerank.rs
@@ -77,7 +77,7 @@ pub fn rerank_index<O: Operator, T>(
                 index.clone(),
                 mean,
                 pay_u,
-                LAccess::new(
+                LTryAccess::new(
                     O::Vector::unpack(vector.as_borrowed()),
                     O::DistanceAccessor::default(),
                 ),

--- a/crates/algorithm/src/vectors.rs
+++ b/crates/algorithm/src/vectors.rs
@@ -29,7 +29,7 @@ pub fn read_for_h1_tuple<
 
 pub fn read_for_h0_tuple<
     O: Operator,
-    A: Accessor1<<O::Vector as Vector>::Element, <O::Vector as Vector>::Metadata>,
+    A: TryAccessor1<<O::Vector as Vector>::Element, <O::Vector as Vector>::Metadata>,
 >(
     index: impl RelationRead,
     mean: IndexPointer,
@@ -48,10 +48,10 @@ pub fn read_for_h0_tuple<
         if tuple.payload() != Some(payload) {
             return None;
         }
-        result.push(tuple.elements());
+        result.push(tuple.elements())?;
         cursor = tuple.metadata_or_pointer();
     }
-    Some(result.finish(cursor.ok()?))
+    result.finish(cursor.ok()?)
 }
 
 pub fn append<O: Operator>(


### PR DESCRIPTION
Consider the following scenario:
1. Process 1 performs a search and finds vector A. It locates `x` (1920 dimensions).
2. Process 2 deletes vector A from the index. `x` (1920 dimensions) and `y` (1 dimension) are deleted.
3. Process 3 inserts vector B into the index. `y` (1920 dimensions) and `z` (1 dimension) are inserted.
4. Process 1 locates `y` (1920 dimensions) and detects a length mismatch, resulting in an error.

Since vector `a` can be deleted and is therefore guaranteed not to be included in the query results, any error related to a during reranking should be silently ignored.
