### PR TITLE
feat: prefetch in reranking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,6 +631,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
+
+[[package]]
 name = "k_means"
 version = "0.0.0"
 dependencies = [
@@ -663,16 +683,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9d6fac27761dabcd4ee73571cdb06b7022dc99089acbe5435691edffaac0f4"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "litemap"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,15 +703,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "mimalloc"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995942f432bbb4822a7e9c3faa87a695185b0d09273ba85f097b54f4e458f2af"
-dependencies = [
- "libmimalloc-sys",
-]
 
 [[package]]
 name = "minimal-lexical"
@@ -1030,13 +1031,12 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha",
  "rand_core",
- "zerocopy",
 ]
 
 [[package]]
@@ -1520,8 +1520,8 @@ dependencies = [
  "always_equal",
  "distance",
  "half 2.6.0",
+ "jemallocator",
  "k_means",
- "mimalloc",
  "paste",
  "pgrx",
  "pgrx-catalog",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,8 @@ toml = "0.8.20"
 validator.workspace = true
 zerocopy.workspace = true
 
-[target.'cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), any(target_os = "linux", target_os = "macos", target_os = "windows")))'.dependencies]
-mimalloc = { version = "*", features = ["local_dynamic_tls"] }
+[target.'cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), target_os = "linux"))'.dependencies]
+jemallocator = { version = "0.5.4", features = ["disable_initial_exec_tls"] }
 
 [lints]
 workspace = true
@@ -56,7 +56,7 @@ edition = "2024"
 [workspace.dependencies]
 half = { version = "2.6.0", features = ["zerocopy"] }
 paste = "1"
-rand = "0.9.0"
+rand = "0.9.1"
 serde = { version = "1", features = ["derive"] }
 validator = { version = "0.20.0", features = ["derive"] }
 zerocopy = { version = "0.8.24", features = ["derive"] }

--- a/crates/algorithm/src/bulkdelete.rs
+++ b/crates/algorithm/src/bulkdelete.rs
@@ -1,10 +1,11 @@
+use crate::closure_lifetime_binder::{id_0, id_1};
 use crate::operator::{FunctionalAccessor, Operator};
 use crate::tuples::*;
-use crate::{Page, RelationWrite, tape};
+use crate::{Page, RelationRead, RelationWrite, tape};
 use std::num::NonZero;
 
 pub fn bulkdelete<O: Operator>(
-    index: impl RelationWrite,
+    index: impl RelationRead + RelationWrite,
     check: impl Fn(),
     callback: impl Fn(NonZero<u64>) -> bool,
 ) {
@@ -24,14 +25,8 @@ pub fn bulkdelete<O: Operator>(
                 tape::read_h1_tape(
                     index.clone(),
                     first,
-                    || {
-                        fn push<T>(_: &mut (), _: &[T]) {}
-                        fn finish<T>(_: (), _: (&T, &T, &T, &T)) -> [(); 32] {
-                            [(); 32]
-                        }
-                        FunctionalAccessor::new((), push, finish)
-                    },
-                    |(), _, first| results.push(first),
+                    || FunctionalAccessor::new((), id_0(|_, _| ()), id_1(|_, _| [(); 32])),
+                    |(), _, first, _| results.push(first),
                     |_| check(),
                 );
             }

--- a/crates/algorithm/src/cache.rs
+++ b/crates/algorithm/src/cache.rs
@@ -1,3 +1,4 @@
+use crate::closure_lifetime_binder::{id_0, id_1};
 use crate::operator::FunctionalAccessor;
 use crate::tuples::{MetaTuple, WithReader};
 use crate::{Page, RelationRead, tape};
@@ -18,14 +19,8 @@ pub fn cache(index: impl RelationRead) -> Vec<u32> {
             tape::read_h1_tape(
                 index.clone(),
                 first,
-                || {
-                    fn push<T>(_: &mut (), _: &[T]) {}
-                    fn finish<T>(_: (), _: (&T, &T, &T, &T)) -> [(); 32] {
-                        [(); 32]
-                    }
-                    FunctionalAccessor::new((), push, finish)
-                },
-                |(), _, first| {
+                || FunctionalAccessor::new((), id_0(|_, _| ()), id_1(|_, _| [(); 32])),
+                |(), _, first, _| {
                     results.push(first);
                 },
                 |id| {

--- a/crates/algorithm/src/closure_lifetime_binder.rs
+++ b/crates/algorithm/src/closure_lifetime_binder.rs
@@ -1,0 +1,44 @@
+// Use stable language features as an alternative to `closure_lifetime_binder`.
+// See https://github.com/rust-lang/rust/issues/97362.
+
+#[inline(always)]
+pub fn id_0<F, A: ?Sized, B: ?Sized, R: ?Sized>(f: F) -> F
+where
+    F: for<'a> FnMut(&'a mut A, &'a B) -> R,
+{
+    f
+}
+
+#[inline(always)]
+pub fn id_1<F, A: ?Sized, B: ?Sized, R: ?Sized>(f: F) -> F
+where
+    F: for<'a> FnMut(A, (&'a B, &'a B, &'a B, &'a B)) -> R,
+{
+    f
+}
+
+#[inline(always)]
+pub fn id_2<F, A: ?Sized, B: ?Sized, C: ?Sized, D: ?Sized, R: ?Sized>(f: F) -> F
+where
+    F: for<'a> FnMut(A, B, C, &'a D) -> R,
+{
+    f
+}
+
+#[inline(always)]
+pub fn id_3<F, T, A: ?Sized>(f: F) -> F
+where
+    T: crate::RelationWrite,
+    F: for<'a> Fn(&'a T, A) -> T::WriteGuard<'a>,
+{
+    f
+}
+
+#[inline(always)]
+pub fn id_4<F, T, A: ?Sized, B: ?Sized, R: ?Sized>(f: F) -> F
+where
+    T: crate::RelationRead,
+    F: FnMut(A, Vec<T::ReadGuard<'_>>, B) -> R,
+{
+    f
+}

--- a/crates/algorithm/src/cost.rs
+++ b/crates/algorithm/src/cost.rs
@@ -1,11 +1,10 @@
 use crate::tuples::{MetaTuple, WithReader};
 use crate::{Page, RelationRead};
-use std::num::NonZero;
 
 pub struct Cost {
     pub dims: u32,
     pub is_residual: bool,
-    pub cells: Vec<NonZero<u32>>,
+    pub cells: Vec<u32>,
 }
 
 #[must_use]
@@ -15,12 +14,12 @@ pub fn cost(index: impl RelationRead) -> Cost {
     let meta_tuple = MetaTuple::deserialize_ref(meta_bytes);
     let dims = meta_tuple.dims();
     let is_residual = meta_tuple.is_residual();
-    let cells = meta_tuple.cells();
+    let cells = meta_tuple.cells().to_vec();
     drop(meta_guard);
 
     Cost {
         dims,
         is_residual,
-        cells: cells.into_iter().map_while(NonZero::new).collect(),
+        cells,
     }
 }

--- a/crates/algorithm/src/insert.rs
+++ b/crates/algorithm/src/insert.rs
@@ -1,9 +1,8 @@
 use crate::linked_vec::LinkedVec;
 use crate::operator::*;
-use crate::select_heap::SelectHeap;
 use crate::tuples::*;
 use crate::vectors::{self};
-use crate::{IndexPointer, Page, RelationWrite, tape};
+use crate::{Bump, Page, Prefetcher, RelationRead, RelationWrite, tape};
 use always_equal::AlwaysEqual;
 use distance::Distance;
 use std::cmp::Reverse;
@@ -11,7 +10,23 @@ use std::collections::BinaryHeap;
 use std::num::NonZero;
 use vector::{VectorBorrowed, VectorOwned};
 
-pub fn insert<O: Operator>(index: impl RelationWrite, payload: NonZero<u64>, vector: O::Vector) {
+type Item<'b> = (
+    Reverse<Distance>,
+    AlwaysEqual<&'b mut (u32, u16, &'b mut [u32])>,
+);
+
+pub fn insert<
+    'b,
+    R: RelationRead + RelationWrite,
+    O: Operator,
+    P: Prefetcher<R = R, Item = Item<'b>>,
+>(
+    index: R,
+    payload: NonZero<u64>,
+    vector: O::Vector,
+    bump: &'b impl Bump,
+    mut prefetch: impl FnMut(Vec<Item<'b>>) -> P,
+) {
     let meta_guard = index.read(0);
     let meta_bytes = meta_guard.get(1).expect("data corruption");
     let meta_tuple = MetaTuple::deserialize_ref(meta_bytes);
@@ -20,7 +35,8 @@ pub fn insert<O: Operator>(index: impl RelationWrite, payload: NonZero<u64>, vec
     let rerank_in_heap = meta_tuple.rerank_in_heap();
     let height_of_root = meta_tuple.height_of_root();
     assert_eq!(dims, vector.as_borrowed().dims(), "unmatched dimensions");
-    let root_mean = meta_tuple.root_mean();
+    let root_prefetch = meta_tuple.root_prefetch().to_vec();
+    let root_head = meta_tuple.root_head();
     let root_first = meta_tuple.root_first();
     let vectors_first = meta_tuple.vectors_first();
     drop(meta_guard);
@@ -31,31 +47,31 @@ pub fn insert<O: Operator>(index: impl RelationWrite, payload: NonZero<u64>, vec
         None
     };
 
-    let mean = if !rerank_in_heap {
+    let (list, head) = if !rerank_in_heap {
         vectors::append::<O>(index.clone(), vectors_first, vector.as_borrowed(), payload)
     } else {
-        IndexPointer::default()
+        (Vec::new(), 0)
     };
 
     type State<O> = (u32, Option<<O as Operator>::Vector>);
     let mut state: State<O> = {
-        let mean = root_mean;
         if is_residual {
-            let residual_u = vectors::read_for_h1_tuple::<O, _>(
-                index.clone(),
-                mean,
+            let list = root_prefetch.into_iter().map(|id| index.read(id));
+            let residual = vectors::read_for_h1_tuple::<R, O, _>(
+                root_head,
+                list,
                 LAccess::new(
                     O::Vector::unpack(vector.as_borrowed()),
                     O::ResidualAccessor::default(),
                 ),
             );
-            (root_first, Some(residual_u))
+            (root_first, Some(residual))
         } else {
             (root_first, None)
         }
     };
-    let step = |state: State<O>| {
-        let mut results = LinkedVec::new();
+    let mut step = |state: State<O>| {
+        let mut results = LinkedVec::<Item<'b>>::new();
         {
             let (first, residual) = state;
             let block_lut = if let Some(residual) = residual {
@@ -69,25 +85,26 @@ pub fn insert<O: Operator>(index: impl RelationWrite, payload: NonZero<u64>, vec
                 index.clone(),
                 first,
                 || RAccess::new((&block_lut.1, block_lut.0), O::BlockAccessor::default()),
-                |(rough, err), mean, first| {
+                |(rough, err), head, first, prefetch| {
                     let lowerbound = Distance::from_f32(rough - err * 1.9);
-                    results.push((Reverse(lowerbound), AlwaysEqual(mean), AlwaysEqual(first)));
+                    results.push((
+                        Reverse(lowerbound),
+                        AlwaysEqual(bump.alloc((first, head, bump.alloc_slice(prefetch)))),
+                    ));
                 },
                 |_| (),
             );
         }
-        let mut heap = SelectHeap::from_vec(results.into_vec());
+        let mut heap = (prefetch)(results.into_vec());
         let mut cache = BinaryHeap::<(Reverse<Distance>, _, _)>::new();
         {
-            while let Some((Reverse(_), AlwaysEqual(mean), AlwaysEqual(first))) =
-                pop_if(&mut heap, |(d, ..)| {
-                    Some(*d) > cache.peek().map(|(d, ..)| *d)
-                })
+            while let Some(((Reverse(_), AlwaysEqual(&mut (first, head, ..))), list)) =
+                heap.pop_if(|(d, _)| Some(*d) > cache.peek().map(|(d, ..)| *d))
             {
                 if is_residual {
-                    let (dis_u, residual_u) = vectors::read_for_h1_tuple::<O, _>(
-                        index.clone(),
-                        mean,
+                    let (distance, residual) = vectors::read_for_h1_tuple::<R, O, _>(
+                        head,
+                        list.into_iter(),
                         LAccess::new(
                             O::Vector::unpack(vector.as_borrowed()),
                             (
@@ -97,20 +114,20 @@ pub fn insert<O: Operator>(index: impl RelationWrite, payload: NonZero<u64>, vec
                         ),
                     );
                     cache.push((
-                        Reverse(dis_u),
+                        Reverse(distance),
                         AlwaysEqual(first),
-                        AlwaysEqual(Some(residual_u)),
+                        AlwaysEqual(Some(residual)),
                     ));
                 } else {
-                    let dis_u = vectors::read_for_h1_tuple::<O, _>(
-                        index.clone(),
-                        mean,
+                    let distance = vectors::read_for_h1_tuple::<R, O, _>(
+                        head,
+                        list.into_iter(),
                         LAccess::new(
                             O::Vector::unpack(vector.as_borrowed()),
                             O::DistanceAccessor::default(),
                         ),
                     );
-                    cache.push((Reverse(dis_u), AlwaysEqual(first), AlwaysEqual(None)));
+                    cache.push((Reverse(distance), AlwaysEqual(first), AlwaysEqual(None)));
                 }
             }
             let (_, AlwaysEqual(first), AlwaysEqual(mean)) = cache
@@ -130,12 +147,13 @@ pub fn insert<O: Operator>(index: impl RelationWrite, payload: NonZero<u64>, vec
         O::Vector::code(vector.as_borrowed())
     };
     let bytes = AppendableTuple::serialize(&AppendableTuple {
-        mean,
+        head,
         dis_u_2: code.dis_u_2,
         factor_ppc: code.factor_ppc,
         factor_ip: code.factor_ip,
         factor_err: code.factor_err,
         payload: Some(payload),
+        prefetch: list,
         elements: rabitq::pack_to_u64(&code.signs),
     });
 
@@ -144,9 +162,4 @@ pub fn insert<O: Operator>(index: impl RelationWrite, payload: NonZero<u64>, vec
     let jump_tuple = JumpTuple::deserialize_ref(jump_bytes);
 
     tape::append(index.clone(), jump_tuple.appendable_first(), &bytes, false);
-}
-
-fn pop_if<T: Ord>(heap: &mut SelectHeap<T>, mut predicate: impl FnMut(&T) -> bool) -> Option<T> {
-    let peek = heap.peek()?;
-    if predicate(peek) { heap.pop() } else { None }
 }

--- a/crates/algorithm/src/lib.rs
+++ b/crates/algorithm/src/lib.rs
@@ -1,15 +1,20 @@
+#![feature(let_chains)]
+#![allow(clippy::type_complexity)]
+
 mod build;
 mod bulkdelete;
 mod cache;
+mod closure_lifetime_binder;
 mod cost;
+mod fast_heap;
 mod freepages;
 mod insert;
 mod linked_vec;
 mod maintain;
+mod prefetcher;
 mod prewarm;
 mod rerank;
 mod search;
-mod select_heap;
 mod tape;
 mod tuples;
 mod vectors;
@@ -17,16 +22,20 @@ mod vectors;
 pub mod operator;
 pub mod types;
 
+use always_equal::AlwaysEqual;
 pub use build::build;
 pub use bulkdelete::bulkdelete;
 pub use cache::cache;
 pub use cost::cost;
+pub use fast_heap::FastHeap;
 pub use insert::insert;
 pub use maintain::maintain;
+pub use prefetcher::{PlainPrefetcher, Prefetcher, SimplePrefetcher, StreamPrefetcher};
 pub use prewarm::prewarm;
 pub use rerank::{how, rerank_heap, rerank_index};
 pub use search::{default_search, maxsim_search};
 
+use std::collections::BinaryHeap;
 use std::ops::{Deref, DerefMut};
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
@@ -64,21 +73,68 @@ pub trait PageGuard {
     fn id(&self) -> u32;
 }
 
-pub trait RelationRead: Clone {
+pub trait ReadStream<T> {
+    type Relation: RelationRead;
+    type Inner: Iterator<Item = T>;
+    fn next_if(
+        &mut self,
+        predicate: impl FnOnce(&T) -> bool,
+    ) -> Option<(T, Vec<<Self::Relation as RelationRead>::ReadGuard<'_>>)>;
+    fn into_inner(self) -> Self::Inner;
+}
+
+pub trait WriteStream<T> {
+    type Relation: RelationWrite;
+    type Inner: Iterator<Item = T>;
+    fn next_if(
+        &mut self,
+        predicate: impl FnOnce(&T) -> bool,
+    ) -> Option<(T, Vec<<Self::Relation as RelationWrite>::WriteGuard<'_>>)>;
+    fn into_inner(self) -> Self::Inner;
+}
+
+pub trait Relation: Clone {
     type Page: Page;
+}
+
+pub trait RelationRead: Relation {
     type ReadGuard<'a>: PageGuard + Deref<Target = Self::Page>
     where
         Self: 'a;
     fn read(&self, id: u32) -> Self::ReadGuard<'_>;
 }
 
-pub trait RelationWrite: RelationRead {
+pub trait RelationWrite: Relation {
     type WriteGuard<'a>: PageGuard + DerefMut<Target = Self::Page>
     where
         Self: 'a;
     fn write(&self, id: u32, tracking_freespace: bool) -> Self::WriteGuard<'_>;
     fn extend(&self, tracking_freespace: bool) -> Self::WriteGuard<'_>;
     fn search(&self, freespace: usize) -> Option<Self::WriteGuard<'_>>;
+}
+
+pub trait RelationPrefetch: Relation {
+    fn prefetch(&self, id: u32);
+}
+
+pub trait RelationReadStream: RelationRead {
+    type ReadStream<'s, I: Iterator>: ReadStream<I::Item, Relation = Self>
+    where
+        I::Item: Fetch,
+        Self: 's;
+    fn read_stream<I: Iterator>(&self, iter: I) -> Self::ReadStream<'_, I>
+    where
+        I::Item: Fetch;
+}
+
+pub trait RelationWriteStream: RelationWrite {
+    type WriteStream<'s, I: Iterator>: WriteStream<I::Item, Relation = Self>
+    where
+        I::Item: Fetch,
+        Self: 's;
+    fn write_stream<I: Iterator>(&self, iter: I) -> Self::WriteStream<'_, I>
+    where
+        I::Item: Fetch;
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -88,17 +144,45 @@ pub enum RerankMethod {
 }
 
 pub(crate) struct Branch<T> {
-    pub mean: IndexPointer,
+    pub head: u16,
     pub dis_u_2: f32,
     pub factor_ppc: f32,
     pub factor_ip: f32,
     pub factor_err: f32,
     pub signs: Vec<bool>,
+    pub prefetch: Vec<u32>,
     pub extra: T,
 }
 
-#[repr(transparent)]
-#[derive(
-    Debug, Default, Clone, Copy, PartialEq, Eq, Hash, IntoBytes, FromBytes, Immutable, KnownLayout,
-)]
-pub struct IndexPointer(pub u64);
+pub trait Fetch {
+    fn fetch(&self) -> &[u32];
+}
+
+impl<'b, T, A, B> Fetch for (T, AlwaysEqual<&'b mut (A, B, &'b mut [u32])>) {
+    fn fetch(&self) -> &[u32] {
+        let (_, AlwaysEqual((.., list))) = self;
+        list
+    }
+}
+
+pub trait Bump: 'static {
+    #[allow(clippy::mut_from_ref)]
+    fn alloc<T>(&self, value: T) -> &mut T;
+    #[allow(clippy::mut_from_ref)]
+    fn alloc_slice<T: Copy>(&self, slice: &[T]) -> &mut [T];
+}
+
+pub trait Heap: IntoIterator {
+    fn make(this: Vec<Self::Item>) -> Self;
+    fn pop_if(&mut self, predicate: impl FnOnce(&Self::Item) -> bool) -> Option<Self::Item>;
+}
+
+impl<T: Ord> Heap for BinaryHeap<T> {
+    fn make(this: Vec<T>) -> Self {
+        Self::from(this)
+    }
+    fn pop_if(&mut self, predicate: impl FnOnce(&T) -> bool) -> Option<T> {
+        let peek = self.peek()?;
+        if predicate(peek) { self.pop() } else { None }
+    }
+}

--- a/crates/algorithm/src/operator.rs
+++ b/crates/algorithm/src/operator.rs
@@ -451,6 +451,8 @@ pub trait Vector: VectorOwned {
 
     fn split(vector: Self::Borrowed<'_>) -> (Vec<&[Self::Element]>, Self::Metadata);
 
+    fn count(n: usize) -> usize;
+
     fn unpack(vector: Self::Borrowed<'_>) -> (&[Self::Element], Self::Metadata);
 
     fn block_preprocess(vector: Self::Borrowed<'_>) -> BlockLut;
@@ -476,6 +478,15 @@ impl Vector for VectOwned<f32> {
             },
             (),
         )
+    }
+
+    fn count(n: usize) -> usize {
+        match n {
+            0 => unreachable!(),
+            1..=960 => 1,
+            961..=1280 => 2,
+            1281.. => n.div_ceil(1920),
+        }
     }
 
     fn unpack(vector: Self::Borrowed<'_>) -> (&[Self::Element], Self::Metadata) {
@@ -511,6 +522,15 @@ impl Vector for VectOwned<f16> {
             },
             (),
         )
+    }
+
+    fn count(n: usize) -> usize {
+        match n {
+            0 => unreachable!(),
+            1..=1920 => 1,
+            1921..=2560 => 2,
+            2561.. => n.div_ceil(3840),
+        }
     }
 
     fn unpack(vector: Self::Borrowed<'_>) -> (&[Self::Element], Self::Metadata) {

--- a/crates/algorithm/src/prefetcher.rs
+++ b/crates/algorithm/src/prefetcher.rs
@@ -1,0 +1,164 @@
+use crate::{Fetch, Heap, ReadStream, RelationPrefetch, RelationRead, RelationReadStream};
+use std::collections::{BinaryHeap, VecDeque, binary_heap, vec_deque};
+use std::iter::Chain;
+
+pub const WINDOW_SIZE: usize = 32;
+const _: () = assert!(WINDOW_SIZE > 0);
+
+pub trait Prefetcher: IntoIterator
+where
+    Self::Item: Fetch,
+{
+    type R: RelationRead;
+    fn pop_if(
+        &mut self,
+        predicate: impl FnOnce(&Self::Item) -> bool,
+    ) -> Option<(Self::Item, Vec<<Self::R as RelationRead>::ReadGuard<'_>>)>;
+}
+
+pub struct PlainPrefetcher<R, H> {
+    relation: R,
+    heap: H,
+}
+
+impl<R, H: Heap> PlainPrefetcher<R, H> {
+    pub fn new(relation: R, vec: Vec<H::Item>) -> Self {
+        Self {
+            relation,
+            heap: Heap::make(vec),
+        }
+    }
+}
+
+impl<R, H: Heap> IntoIterator for PlainPrefetcher<R, H> {
+    type Item = H::Item;
+
+    type IntoIter = H::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.heap.into_iter()
+    }
+}
+
+impl<R: RelationRead, H: Heap> Prefetcher for PlainPrefetcher<R, H>
+where
+    H::Item: Fetch + Ord,
+{
+    type R = R;
+    fn pop_if<'s>(
+        &'s mut self,
+        predicate: impl FnOnce(&Self::Item) -> bool,
+    ) -> Option<(H::Item, Vec<R::ReadGuard<'s>>)> {
+        let e = self.heap.pop_if(predicate)?;
+        let list = e.fetch().iter().map(|&id| self.relation.read(id)).collect();
+        Some((e, list))
+    }
+}
+
+pub struct SimplePrefetcher<R, T> {
+    relation: R,
+    window: VecDeque<T>,
+    heap: BinaryHeap<T>,
+}
+
+impl<R, T: Ord> SimplePrefetcher<R, T> {
+    pub fn new(relation: R, vec: Vec<T>) -> Self {
+        Self {
+            relation,
+            window: VecDeque::new(),
+            heap: BinaryHeap::from(vec),
+        }
+    }
+}
+
+impl<R, T> IntoIterator for SimplePrefetcher<R, T> {
+    type Item = T;
+
+    type IntoIter = Chain<vec_deque::IntoIter<T>, binary_heap::IntoIter<T>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.window.into_iter().chain(self.heap)
+    }
+}
+
+impl<R: RelationRead + RelationPrefetch, T: Fetch + Ord> Prefetcher for SimplePrefetcher<R, T> {
+    type R = R;
+    fn pop_if<'s>(
+        &'s mut self,
+        predicate: impl FnOnce(&Self::Item) -> bool,
+    ) -> Option<(T, Vec<R::ReadGuard<'s>>)> {
+        while self.window.len() < WINDOW_SIZE
+            && let Some(e) = self.heap.pop()
+        {
+            for id in e.fetch().iter().copied() {
+                self.relation.prefetch(id);
+            }
+            self.window.push_back(e);
+        }
+        let e = vec_deque_pop_front_if(&mut self.window, predicate)?;
+        let list = e.fetch().iter().map(|&id| self.relation.read(id)).collect();
+        Some((e, list))
+    }
+}
+
+pub struct StreamPrefetcherHeap<T>(BinaryHeap<T>);
+
+impl<T: Ord> Iterator for StreamPrefetcherHeap<T> {
+    type Item = T;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.pop()
+    }
+}
+
+pub struct StreamPrefetcher<'r, R, T>
+where
+    R: RelationReadStream + 'r,
+    T: Fetch + Ord,
+{
+    stream: R::ReadStream<'r, StreamPrefetcherHeap<T>>,
+}
+
+impl<'r, R: RelationReadStream, T: Fetch + Ord> StreamPrefetcher<'r, R, T> {
+    pub fn new(relation: &'r R, vec: Vec<T>) -> Self {
+        let stream = relation.read_stream(StreamPrefetcherHeap(BinaryHeap::from(vec)));
+        Self { stream }
+    }
+}
+
+impl<'r, R: RelationReadStream, T: Fetch + Ord> IntoIterator for StreamPrefetcher<'r, R, T> {
+    type Item = T;
+
+    type IntoIter = <<R as RelationReadStream>::ReadStream<
+        'r,
+        StreamPrefetcherHeap<T>,
+    > as ReadStream<T>>::Inner;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.stream.into_inner()
+    }
+}
+
+impl<'r, R: RelationReadStream, T: Fetch + Ord> Prefetcher for StreamPrefetcher<'r, R, T> {
+    type R = R;
+    fn pop_if<'s>(
+        &'s mut self,
+        predicate: impl FnOnce(&Self::Item) -> bool,
+    ) -> Option<(T, Vec<R::ReadGuard<'s>>)> {
+        self.stream.next_if(predicate)
+    }
+}
+
+// Emulate unstable library feature `vec_deque_pop_if`.
+// See https://github.com/rust-lang/rust/issues/135889.
+
+fn vec_deque_pop_front_if<T>(
+    this: &mut VecDeque<T>,
+    predicate: impl FnOnce(&T) -> bool,
+) -> Option<T> {
+    let first = this.front()?;
+    if predicate(first) {
+        this.pop_front()
+    } else {
+        None
+    }
+}

--- a/crates/algorithm/src/vectors.rs
+++ b/crates/algorithm/src/vectors.rs
@@ -1,46 +1,53 @@
 use crate::operator::*;
 use crate::tuples::*;
-use crate::{IndexPointer, Page, PageGuard, RelationRead, RelationWrite, tape};
+use crate::{Page, PageGuard, RelationRead, RelationWrite, tape};
 use std::num::NonZero;
 use vector::VectorOwned;
 
 pub fn read_for_h1_tuple<
+    'a,
+    R: RelationRead + 'a,
     O: Operator,
     A: Accessor1<<O::Vector as Vector>::Element, <O::Vector as Vector>::Metadata>,
 >(
-    index: impl RelationRead,
-    mean: IndexPointer,
+    head: u16,
+    mut list: impl Iterator<Item = R::ReadGuard<'a>>,
     accessor: A,
 ) -> A::Output {
-    let mut cursor = Err(mean);
+    let mut cursor = Err(head);
     let mut result = accessor;
-    while let Err(mean) = cursor.map_err(pointer_to_pair) {
-        let guard = index.read(mean.0);
-        let bytes = guard.get(mean.1).expect("data corruption");
+    while let Err(head) = cursor {
+        let guard = list.next().expect("data corruption");
+        let bytes = guard.get(head).expect("data corruption");
         let tuple = VectorTuple::<O::Vector>::deserialize_ref(bytes);
         if tuple.payload().is_some() {
             panic!("data corruption");
         }
         result.push(tuple.elements());
-        cursor = tuple.metadata_or_pointer();
+        cursor = tuple.metadata_or_head();
+    }
+    if list.next().is_some() {
+        panic!("data corruption");
     }
     result.finish(cursor.expect("data corruption"))
 }
 
 pub fn read_for_h0_tuple<
+    'a,
+    R: RelationRead + 'a,
     O: Operator,
     A: TryAccessor1<<O::Vector as Vector>::Element, <O::Vector as Vector>::Metadata>,
 >(
-    index: impl RelationRead,
-    mean: IndexPointer,
+    head: u16,
+    mut list: impl Iterator<Item = R::ReadGuard<'a>>,
     payload: NonZero<u64>,
     accessor: A,
 ) -> Option<A::Output> {
-    let mut cursor = Err(mean);
+    let mut cursor = Err(head);
     let mut result = accessor;
-    while let Err(mean) = cursor.map_err(pointer_to_pair) {
-        let guard = index.read(mean.0);
-        let bytes = guard.get(mean.1)?;
+    while let Err(head) = cursor {
+        let guard = list.next()?;
+        let bytes = guard.get(head)?;
         let tuple = VectorTuple::<O::Vector>::deserialize_ref(bytes);
         if tuple.payload().is_none() {
             panic!("data corruption");
@@ -49,28 +56,32 @@ pub fn read_for_h0_tuple<
             return None;
         }
         result.push(tuple.elements())?;
-        cursor = tuple.metadata_or_pointer();
+        cursor = tuple.metadata_or_head();
+    }
+    if list.next().is_some() {
+        return None;
     }
     result.finish(cursor.ok()?)
 }
 
 pub fn append<O: Operator>(
-    index: impl RelationWrite,
+    index: impl RelationRead + RelationWrite,
     vectors_first: u32,
     vector: <O::Vector as VectorOwned>::Borrowed<'_>,
     payload: NonZero<u64>,
-) -> IndexPointer {
-    fn append(index: impl RelationWrite, first: u32, bytes: &[u8]) -> IndexPointer {
+) -> (Vec<u32>, u16) {
+    fn append(index: impl RelationRead + RelationWrite, first: u32, bytes: &[u8]) -> (u32, u16) {
         if let Some(mut write) = index.search(bytes.len()) {
             let i = write
                 .alloc(bytes)
                 .expect("implementation: a free page cannot accommodate a single tuple");
-            return pair_to_pointer((write.id(), i));
+            return (write.id(), i);
         }
         tape::append(index, first, bytes, true)
     }
     let (slices, metadata) = O::Vector::split(vector);
     let mut chain = Ok(metadata);
+    let mut prefetch = Vec::new();
     for i in (0..slices.len()).rev() {
         let bytes = VectorTuple::<O::Vector>::serialize(&match chain {
             Ok(metadata) => VectorTuple::_0 {
@@ -78,13 +89,19 @@ pub fn append<O: Operator>(
                 payload: Some(payload),
                 metadata,
             },
-            Err(pointer) => VectorTuple::_1 {
+            Err(head) => VectorTuple::_1 {
                 elements: slices[i].to_vec(),
                 payload: Some(payload),
-                pointer,
+                head,
             },
         });
-        chain = Err(append(index.clone(), vectors_first, &bytes));
+        let (id, head) = append(index.clone(), vectors_first, &bytes);
+        chain = Err(head);
+        prefetch.push(id);
     }
-    chain.expect_err("internal error: 0-dimensional vector")
+    prefetch.reverse();
+    (
+        prefetch,
+        chain.expect_err("internal error: 0-dimensional vector"),
+    )
 }

--- a/crates/simd/src/lib.rs
+++ b/crates/simd/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(avx512_target_feature)]
+#![cfg_attr(target_arch = "x86_64", feature(avx512_target_feature))]
 #![cfg_attr(target_arch = "x86_64", feature(stdarch_x86_avx512))]
 #![cfg_attr(target_arch = "x86_64", feature(stdarch_x86_avx512_f16))]
 #![allow(unsafe_code)]

--- a/src/index/algorithm.rs
+++ b/src/index/algorithm.rs
@@ -2,11 +2,191 @@ use super::opclass::Opfamily;
 use crate::index::am::am_build::InternalBuild;
 use algorithm::operator::{Dot, L2, Op};
 use algorithm::types::*;
-use algorithm::{RelationRead, RelationWrite};
+use algorithm::{Bump, RelationRead, RelationWrite};
 use half::f16;
+use std::cell::UnsafeCell;
+use std::mem::MaybeUninit;
 use std::num::NonZero;
 use vector::VectorOwned;
 use vector::vect::{VectBorrowed, VectOwned};
+
+#[repr(C, align(4096))]
+struct Chunk([u8; 2 * 1024 * 1024]);
+
+struct Allocator {
+    used: Vec<*mut MaybeUninit<Chunk>>,
+    free: Vec<*mut MaybeUninit<Chunk>>,
+    this: *mut MaybeUninit<u8>,
+    size: usize,
+}
+
+impl Allocator {
+    pub fn new() -> Self {
+        Self {
+            used: Vec::new(),
+            free: Vec::new(),
+            this: Box::into_raw(Box::<Chunk>::new_uninit()).cast(),
+            size: size_of::<Chunk>(),
+        }
+    }
+    pub fn malloc<T>(&mut self) -> *mut T {
+        const {
+            assert!(align_of::<T>() <= align_of::<Chunk>());
+            assert!(size_of::<T>() <= size_of::<Chunk>());
+        }
+        if size_of::<T>() <= self.size {
+            self.size = (self.size - size_of::<T>()) / align_of::<T>() * align_of::<T>();
+            unsafe { self.this.add(self.size).cast::<T>() }
+        } else {
+            #[cold]
+            fn cold<T>(sel: &mut Allocator) -> *mut T {
+                std::panic::abort_unwind(|| {
+                    let raw = std::mem::replace(&mut sel.this, std::ptr::null_mut());
+                    sel.used.push(raw.cast());
+                    sel.this = sel
+                        .free
+                        .pop()
+                        .unwrap_or_else(|| Box::into_raw(Box::<Chunk>::new_uninit()))
+                        .cast();
+                    sel.size = size_of::<Chunk>();
+                });
+                sel.size = (sel.size - size_of::<T>()) / align_of::<T>() * align_of::<T>();
+                unsafe { sel.this.add(sel.size).cast::<T>() }
+            }
+            cold(self)
+        }
+    }
+    pub fn malloc_n<T>(&mut self, n: usize) -> *mut T {
+        const {
+            assert!(align_of::<T>() <= align_of::<Chunk>());
+        }
+        let limit = const {
+            if size_of::<T>() > 0 {
+                size_of::<Chunk>() / size_of::<T>()
+            } else {
+                usize::MAX
+            }
+        };
+        if n <= limit && n * size_of::<T>() <= self.size {
+            self.size = (self.size - n * size_of::<T>()) / align_of::<T>() * align_of::<T>();
+            unsafe { self.this.add(self.size).cast::<T>() }
+        } else {
+            #[cold]
+            fn cold<T>(sel: &mut Allocator, n: usize) -> *mut T {
+                std::panic::abort_unwind(|| {
+                    let raw = std::mem::replace(&mut sel.this, std::ptr::null_mut());
+                    sel.used.push(raw.cast());
+                    sel.this = sel
+                        .free
+                        .pop()
+                        .unwrap_or_else(|| Box::into_raw(Box::<Chunk>::new_uninit()))
+                        .cast();
+                    sel.size = size_of::<Chunk>();
+                });
+                sel.size = (sel.size - n * size_of::<T>()) / align_of::<T>() * align_of::<T>();
+                unsafe { sel.this.add(sel.size).cast::<T>() }
+            }
+            if n > limit {
+                panic!("failed to allocate memory");
+            }
+            cold(self, n)
+        }
+    }
+    pub fn reset(&mut self) {
+        std::panic::abort_unwind(|| {
+            self.free.extend(std::mem::take(&mut self.used));
+            self.size = size_of::<Chunk>();
+        });
+    }
+}
+
+impl Drop for Allocator {
+    fn drop(&mut self) {
+        for raw in self.used.iter().copied() {
+            unsafe {
+                let _ = Box::<MaybeUninit<Chunk>>::from_raw(raw);
+            }
+        }
+        for raw in self.free.iter().copied() {
+            unsafe {
+                let _ = Box::<MaybeUninit<Chunk>>::from_raw(raw);
+            }
+        }
+        unsafe {
+            let _ = Box::<MaybeUninit<Chunk>>::from_raw(self.this.cast());
+        }
+    }
+}
+
+#[test]
+fn test_allocator() {
+    let mut allocator = Allocator::new();
+    for _ in 0..1024 * 8 {
+        allocator.malloc::<()>();
+        allocator.malloc::<u8>();
+        allocator.malloc::<u32>();
+        allocator.malloc::<u8>();
+        allocator.malloc::<[u8; 32]>();
+        allocator.malloc_n::<u32>(2);
+        allocator.malloc::<[u8; 32]>();
+        allocator.malloc_n::<u32>(2);
+        allocator.malloc_n::<u32>(2);
+        allocator.malloc_n::<u32>(2);
+        allocator.malloc_n::<u32>(2);
+        allocator.malloc_n::<u32>(2);
+    }
+    let number_of_chunks_0 = 1 + allocator.used.len() + allocator.free.len();
+    allocator.reset();
+    for _ in 0..1024 * 8 {
+        allocator.malloc::<()>();
+        allocator.malloc::<u8>();
+        allocator.malloc::<u32>();
+        allocator.malloc::<u8>();
+        allocator.malloc::<[u8; 32]>();
+        allocator.malloc_n::<u32>(2);
+        allocator.malloc::<[u8; 32]>();
+        allocator.malloc_n::<u32>(2);
+        allocator.malloc_n::<u32>(2);
+        allocator.malloc_n::<u32>(2);
+        allocator.malloc_n::<u32>(2);
+        allocator.malloc_n::<u32>(2);
+    }
+    let number_of_chunks_1 = 1 + allocator.used.len() + allocator.free.len();
+    assert_eq!(number_of_chunks_0, number_of_chunks_1);
+}
+
+pub struct BumpAlloc {
+    inner: UnsafeCell<Allocator>,
+}
+
+impl BumpAlloc {
+    pub fn new() -> Self {
+        Self {
+            inner: UnsafeCell::new(Allocator::new()),
+        }
+    }
+    pub fn reset(&mut self) {
+        self.inner.get_mut().reset();
+    }
+}
+
+impl Bump for BumpAlloc {
+    fn alloc<T>(&self, value: T) -> &mut T {
+        unsafe {
+            let ptr = (*self.inner.get()).malloc::<T>();
+            ptr.write(value);
+            &mut *ptr
+        }
+    }
+
+    fn alloc_slice<T: Copy>(&self, slice: &[T]) -> &mut [T] {
+        unsafe {
+            let ptr = (*self.inner.get()).malloc_n::<T>(slice.len());
+            std::ptr::copy_nonoverlapping(slice.as_ptr(), ptr, slice.len());
+            std::slice::from_raw_parts_mut(ptr, slice.len())
+        }
+    }
+}
 
 pub fn prewarm(
     opfamily: Opfamily,
@@ -16,16 +196,16 @@ pub fn prewarm(
 ) -> String {
     let message = match (opfamily.vector_kind(), opfamily.distance_kind()) {
         (VectorKind::Vecf32, DistanceKind::L2) => {
-            algorithm::prewarm::<Op<VectOwned<f32>, L2>>(index, height, check)
+            algorithm::prewarm::<_, Op<VectOwned<f32>, L2>>(index, height, check)
         }
         (VectorKind::Vecf32, DistanceKind::Dot) => {
-            algorithm::prewarm::<Op<VectOwned<f32>, Dot>>(index, height, check)
+            algorithm::prewarm::<_, Op<VectOwned<f32>, Dot>>(index, height, check)
         }
         (VectorKind::Vecf16, DistanceKind::L2) => {
-            algorithm::prewarm::<Op<VectOwned<f16>, L2>>(index, height, check)
+            algorithm::prewarm::<_, Op<VectOwned<f16>, L2>>(index, height, check)
         }
         (VectorKind::Vecf16, DistanceKind::Dot) => {
-            algorithm::prewarm::<Op<VectOwned<f16>, Dot>>(index, height, check)
+            algorithm::prewarm::<_, Op<VectOwned<f16>, Dot>>(index, height, check)
         }
     };
     match message {
@@ -36,7 +216,7 @@ pub fn prewarm(
 
 pub fn bulkdelete(
     opfamily: Opfamily,
-    index: impl RelationWrite,
+    index: impl RelationRead + RelationWrite,
     check: impl Fn(),
     callback: impl Fn(NonZero<u64>) -> bool,
 ) {
@@ -56,19 +236,19 @@ pub fn bulkdelete(
     }
 }
 
-pub fn maintain(opfamily: Opfamily, index: impl RelationWrite, check: impl Fn()) {
+pub fn maintain(opfamily: Opfamily, index: impl RelationRead + RelationWrite, check: impl Fn()) {
     match (opfamily.vector_kind(), opfamily.distance_kind()) {
         (VectorKind::Vecf32, DistanceKind::L2) => {
-            algorithm::maintain::<Op<VectOwned<f32>, L2>>(index, check)
+            algorithm::maintain::<Op<VectOwned<f32>, L2>, _>(index, check)
         }
         (VectorKind::Vecf32, DistanceKind::Dot) => {
-            algorithm::maintain::<Op<VectOwned<f32>, Dot>>(index, check)
+            algorithm::maintain::<Op<VectOwned<f32>, Dot>, _>(index, check)
         }
         (VectorKind::Vecf16, DistanceKind::L2) => {
-            algorithm::maintain::<Op<VectOwned<f16>, L2>>(index, check)
+            algorithm::maintain::<Op<VectOwned<f16>, L2>, _>(index, check)
         }
         (VectorKind::Vecf16, DistanceKind::Dot) => {
-            algorithm::maintain::<Op<VectOwned<f16>, Dot>>(index, check)
+            algorithm::maintain::<Op<VectOwned<f16>, Dot>, _>(index, check)
         }
     }
 }
@@ -109,41 +289,55 @@ pub fn build(
 
 pub fn insert(
     opfamily: Opfamily,
-    index: impl RelationWrite,
+    index: impl RelationRead + RelationWrite,
     payload: NonZero<u64>,
     vector: OwnedVector,
 ) {
+    use algorithm::{FastHeap, PlainPrefetcher};
+    let bump = BumpAlloc::new();
+    let prefetch = {
+        let index = index.clone();
+        move |results| PlainPrefetcher::<_, FastHeap<_>>::new(index.clone(), results)
+    };
     match (vector, opfamily.distance_kind()) {
         (OwnedVector::Vecf32(vector), DistanceKind::L2) => {
             assert!(opfamily.vector_kind() == VectorKind::Vecf32);
-            algorithm::insert::<Op<VectOwned<f32>, L2>>(
+            algorithm::insert::<_, Op<VectOwned<f32>, L2>, _>(
                 index,
                 payload,
                 RandomProject::project(vector.as_borrowed()),
+                &bump,
+                prefetch,
             )
         }
         (OwnedVector::Vecf32(vector), DistanceKind::Dot) => {
             assert!(opfamily.vector_kind() == VectorKind::Vecf32);
-            algorithm::insert::<Op<VectOwned<f32>, Dot>>(
+            algorithm::insert::<_, Op<VectOwned<f32>, Dot>, _>(
                 index,
                 payload,
                 RandomProject::project(vector.as_borrowed()),
+                &bump,
+                prefetch,
             )
         }
         (OwnedVector::Vecf16(vector), DistanceKind::L2) => {
             assert!(opfamily.vector_kind() == VectorKind::Vecf16);
-            algorithm::insert::<Op<VectOwned<f16>, L2>>(
+            algorithm::insert::<_, Op<VectOwned<f16>, L2>, _>(
                 index,
                 payload,
                 RandomProject::project(vector.as_borrowed()),
+                &bump,
+                prefetch,
             )
         }
         (OwnedVector::Vecf16(vector), DistanceKind::Dot) => {
             assert!(opfamily.vector_kind() == VectorKind::Vecf16);
-            algorithm::insert::<Op<VectOwned<f16>, Dot>>(
+            algorithm::insert::<_, Op<VectOwned<f16>, Dot>, _>(
                 index,
                 payload,
                 RandomProject::project(vector.as_borrowed()),
+                &bump,
+                prefetch,
             )
         }
     }

--- a/src/index/am/am_build.rs
+++ b/src/index/am/am_build.rs
@@ -4,7 +4,7 @@ use crate::index::opclass::{Opfamily, opfamily};
 use crate::index::storage::{PostgresPage, PostgresRelation};
 use crate::index::types::*;
 use algorithm::types::*;
-use algorithm::{PageGuard, RelationRead, RelationWrite};
+use algorithm::{PageGuard, Relation, RelationRead, RelationWrite};
 use half::f16;
 use pgrx::pg_sys::{Datum, ItemPointerData};
 use rand::Rng;
@@ -1274,9 +1274,11 @@ impl<G: Deref> Deref for CachingRelationReadGuard<'_, G> {
     }
 }
 
-impl<R: RelationRead<Page = PostgresPage>> RelationRead for CachingRelation<'_, R> {
+impl<R: Relation> Relation for CachingRelation<'_, R> {
     type Page = R::Page;
+}
 
+impl<R: RelationRead<Page = PostgresPage>> RelationRead for CachingRelation<'_, R> {
     type ReadGuard<'a>
         = CachingRelationReadGuard<'a, R::ReadGuard<'a>>
     where

--- a/src/index/lazy_cell.rs
+++ b/src/index/lazy_cell.rs
@@ -1,0 +1,312 @@
+// Emulate unstable library feature `lazy_get`.
+// See https://github.com/rust-lang/rust/issues/129333.
+
+#![allow(dead_code)]
+
+use core::cell::UnsafeCell;
+use core::hint::unreachable_unchecked;
+use core::ops::Deref;
+
+enum State<T, F> {
+    Uninit(F),
+    Init(T),
+    Poisoned,
+}
+
+/// A value which is initialized on the first access.
+///
+/// For a thread-safe version of this struct, see [`std::sync::LazyLock`].
+///
+/// [`std::sync::LazyLock`]: ../../std/sync/struct.LazyLock.html
+///
+/// # Examples
+///
+/// ```
+/// use std::cell::LazyCell;
+///
+/// let lazy: LazyCell<i32> = LazyCell::new(|| {
+///     println!("initializing");
+///     92
+/// });
+/// println!("ready");
+/// println!("{}", *lazy);
+/// println!("{}", *lazy);
+///
+/// // Prints:
+/// //   ready
+/// //   initializing
+/// //   92
+/// //   92
+/// ```
+pub struct LazyCell<T, F = fn() -> T> {
+    state: UnsafeCell<State<T, F>>,
+}
+
+impl<T, F: FnOnce() -> T> LazyCell<T, F> {
+    /// Creates a new lazy value with the given initializing function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::cell::LazyCell;
+    ///
+    /// let hello = "Hello, World!".to_string();
+    ///
+    /// let lazy = LazyCell::new(|| hello.to_uppercase());
+    ///
+    /// assert_eq!(&*lazy, "HELLO, WORLD!");
+    /// ```
+    #[inline]
+    pub const fn new(f: F) -> LazyCell<T, F> {
+        LazyCell {
+            state: UnsafeCell::new(State::Uninit(f)),
+        }
+    }
+
+    /// Consumes this `LazyCell` returning the stored value.
+    ///
+    /// Returns `Ok(value)` if `Lazy` is initialized and `Err(f)` otherwise.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(lazy_cell_into_inner)]
+    ///
+    /// use std::cell::LazyCell;
+    ///
+    /// let hello = "Hello, World!".to_string();
+    ///
+    /// let lazy = LazyCell::new(|| hello.to_uppercase());
+    ///
+    /// assert_eq!(&*lazy, "HELLO, WORLD!");
+    /// assert_eq!(LazyCell::into_inner(lazy).ok(), Some("HELLO, WORLD!".to_string()));
+    /// ```
+    pub fn into_inner(this: Self) -> Result<T, F> {
+        match this.state.into_inner() {
+            State::Init(data) => Ok(data),
+            State::Uninit(f) => Err(f),
+            State::Poisoned => panic_poisoned(),
+        }
+    }
+
+    /// Forces the evaluation of this lazy value and returns a reference to
+    /// the result.
+    ///
+    /// This is equivalent to the `Deref` impl, but is explicit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::cell::LazyCell;
+    ///
+    /// let lazy = LazyCell::new(|| 92);
+    ///
+    /// assert_eq!(LazyCell::force(&lazy), &92);
+    /// assert_eq!(&*lazy, &92);
+    /// ```
+    #[inline]
+    pub fn force(this: &LazyCell<T, F>) -> &T {
+        // SAFETY:
+        // This invalidates any mutable references to the data. The resulting
+        // reference lives either until the end of the borrow of `this` (in the
+        // initialized case) or is invalidated in `really_init` (in the
+        // uninitialized case; `really_init` will create and return a fresh reference).
+        let state = unsafe { &*this.state.get() };
+        match state {
+            State::Init(data) => data,
+            // SAFETY: The state is uninitialized.
+            State::Uninit(_) => unsafe { LazyCell::really_init(this) },
+            State::Poisoned => panic_poisoned(),
+        }
+    }
+
+    /// Forces the evaluation of this lazy value and returns a mutable reference to
+    /// the result.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(lazy_get)]
+    /// use std::cell::LazyCell;
+    ///
+    /// let mut lazy = LazyCell::new(|| 92);
+    ///
+    /// let p = LazyCell::force_mut(&mut lazy);
+    /// assert_eq!(*p, 92);
+    /// *p = 44;
+    /// assert_eq!(*lazy, 44);
+    /// ```
+    #[inline]
+    pub fn force_mut(this: &mut LazyCell<T, F>) -> &mut T {
+        #[cold]
+        /// # Safety
+        /// May only be called when the state is `Uninit`.
+        unsafe fn really_init_mut<T, F: FnOnce() -> T>(state: &mut State<T, F>) -> &mut T {
+            // INVARIANT: Always valid, but the value may not be dropped.
+            struct PoisonOnPanic<T, F>(*mut State<T, F>);
+            impl<T, F> Drop for PoisonOnPanic<T, F> {
+                #[inline]
+                fn drop(&mut self) {
+                    // SAFETY: Invariant states it is valid, and we don't drop the old value.
+                    unsafe {
+                        self.0.write(State::Poisoned);
+                    }
+                }
+            }
+
+            let State::Uninit(f) = state else {
+                // `unreachable!()` here won't optimize out because the function is cold.
+                // SAFETY: Precondition.
+                unsafe { unreachable_unchecked() };
+            };
+            // SAFETY: We never drop the state after we read `f`, and we write a valid value back
+            // in any case, panic or success. `f` can't access the `LazyCell` because it is mutably
+            // borrowed.
+            let f = unsafe { core::ptr::read(f) };
+            // INVARIANT: Initiated from mutable reference, don't drop because we read it.
+            let guard = PoisonOnPanic(state);
+            let data = f();
+            // SAFETY: `PoisonOnPanic` invariant, and we don't drop the old value.
+            unsafe {
+                core::ptr::write(guard.0, State::Init(data));
+            }
+            core::mem::forget(guard);
+            let State::Init(data) = state else {
+                unreachable!()
+            };
+            data
+        }
+
+        let state = this.state.get_mut();
+        match state {
+            State::Init(data) => data,
+            // SAFETY: `state` is `Uninit`.
+            State::Uninit(_) => unsafe { really_init_mut(state) },
+            State::Poisoned => panic_poisoned(),
+        }
+    }
+
+    /// # Safety
+    /// May only be called when the state is `Uninit`.
+    #[cold]
+    unsafe fn really_init(this: &LazyCell<T, F>) -> &T {
+        // SAFETY:
+        // This function is only called when the state is uninitialized,
+        // so no references to `state` can exist except for the reference
+        // in `force`, which is invalidated here and not accessed again.
+        let state = unsafe { &mut *this.state.get() };
+        // Temporarily mark the state as poisoned. This prevents reentrant
+        // accesses and correctly poisons the cell if the closure panicked.
+        let State::Uninit(f) = core::mem::replace(state, State::Poisoned) else {
+            unreachable!()
+        };
+
+        let data = f();
+
+        // SAFETY:
+        // If the closure accessed the cell through something like a reentrant
+        // mutex, but caught the panic resulting from the state being poisoned,
+        // the mutable borrow for `state` will be invalidated, so we need to
+        // go through the `UnsafeCell` pointer here. The state can only be
+        // poisoned at this point, so using `write` to skip the destructor
+        // of `State` should help the optimizer.
+        unsafe { this.state.get().write(State::Init(data)) };
+
+        // SAFETY:
+        // The previous references were invalidated by the `write` call above,
+        // so do a new shared borrow of the state instead.
+        let state = unsafe { &*this.state.get() };
+        let State::Init(data) = state else {
+            unreachable!()
+        };
+        data
+    }
+}
+
+impl<T, F> LazyCell<T, F> {
+    /// Returns a mutable reference to the value if initialized, or `None` if not.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(lazy_get)]
+    ///
+    /// use std::cell::LazyCell;
+    ///
+    /// let mut lazy = LazyCell::new(|| 92);
+    ///
+    /// assert_eq!(LazyCell::get_mut(&mut lazy), None);
+    /// let _ = LazyCell::force(&lazy);
+    /// *LazyCell::get_mut(&mut lazy).unwrap() = 44;
+    /// assert_eq!(*lazy, 44);
+    /// ```
+    #[inline]
+    pub fn get_mut(this: &mut LazyCell<T, F>) -> Option<&mut T> {
+        let state = this.state.get_mut();
+        match state {
+            State::Init(data) => Some(data),
+            _ => None,
+        }
+    }
+
+    /// Returns a reference to the value if initialized, or `None` if not.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(lazy_get)]
+    ///
+    /// use std::cell::LazyCell;
+    ///
+    /// let lazy = LazyCell::new(|| 92);
+    ///
+    /// assert_eq!(LazyCell::get(&lazy), None);
+    /// let _ = LazyCell::force(&lazy);
+    /// assert_eq!(LazyCell::get(&lazy), Some(&92));
+    /// ```
+    #[inline]
+    pub fn get(this: &LazyCell<T, F>) -> Option<&T> {
+        // SAFETY:
+        // This is sound for the same reason as in `force`: once the state is
+        // initialized, it will not be mutably accessed again, so this reference
+        // will stay valid for the duration of the borrow to `self`.
+        let state = unsafe { &*this.state.get() };
+        match state {
+            State::Init(data) => Some(data),
+            _ => None,
+        }
+    }
+}
+
+impl<T, F: FnOnce() -> T> Deref for LazyCell<T, F> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        LazyCell::force(self)
+    }
+}
+
+impl<T: Default> Default for LazyCell<T> {
+    /// Creates a new lazy value using `Default` as the initializing function.
+    #[inline]
+    fn default() -> LazyCell<T> {
+        LazyCell::new(T::default)
+    }
+}
+
+impl<T: core::fmt::Debug, F> core::fmt::Debug for LazyCell<T, F> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut d = f.debug_tuple("LazyCell");
+        match LazyCell::get(self) {
+            Some(data) => d.field(data),
+            None => d.field(&format_args!("<uninit>")),
+        };
+        d.finish()
+    }
+}
+
+#[cold]
+#[inline(never)]
+const fn panic_poisoned() -> ! {
+    panic!("LazyCell instance has previously been poisoned")
+}

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -3,6 +3,7 @@ pub mod am;
 pub mod functions;
 pub mod gucs;
 pub mod hook;
+pub mod lazy_cell;
 pub mod opclass;
 pub mod projection;
 pub mod scanners;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(unsafe_code)]
-#![feature(lazy_get)]
+#![feature(let_chains)]
+#![feature(abort_unwind)]
 
 mod datatype;
 mod index;
@@ -26,7 +27,8 @@ extern "C-unwind" fn _PG_init() {
 #[cfg(not(target_endian = "little"))]
 compile_error!("Target architecture is not supported.");
 
+#[cfg(not(miri))]
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(target_os = "linux")]
 #[global_allocator]
-static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL_ALLOCATOR: jemallocator::Jemalloc = jemallocator::Jemalloc;


### PR DESCRIPTION
adds a GUC `io_rerank`, with the following possible values:

* `read_buffer`: indicates a preference for `ReadBuffer`.
* `prefetch_buffer`: indicates a preference for both `PrefetchBuffer` and `ReadBuffer`; it's good for disk vector search; this is default on PostgreSQL 13, 14, 15, 16.
* `read_stream`: indicates a preference for `read_stream`; it's good for disk vector search; this option is only available in PostgreSQL 17; this is default on PostgreSQL 17.

notes:

* prefetching distance of `prefetch_buffer` depends on the compile-time constant `WINDOW_SIZE`.
* prefetching distance of `read_stream` depends on the GUC parameter `effective_io_concurrency`.
* prefetching for the bit vector has not been implemented.
* prefetching for the centroid has been implemented, but disabled.