### PR TITLE
feat: prefilter index

### DIFF
--- a/crates/algorithm/src/fast_heap.rs
+++ b/crates/algorithm/src/fast_heap.rs
@@ -75,6 +75,19 @@ impl<T: Ord> Heap for FastHeap<T> {
         let first = self.peek()?;
         if predicate(first) { self.pop() } else { None }
     }
+
+    fn pop_if_with<A>(
+        &mut self,
+        predicate: impl FnOnce(&Self::Item) -> (bool, A),
+    ) -> Option<(Self::Item, A)> {
+        let first = self.peek()?;
+        let (result, another) = predicate(first);
+        if result {
+            self.pop().map(|peek| (peek, another))
+        } else {
+            None
+        }
+    }
 }
 
 #[test]

--- a/crates/algorithm/src/prefetcher.rs
+++ b/crates/algorithm/src/prefetcher.rs
@@ -1,6 +1,8 @@
+use crate::operator::Operator;
 use crate::{Fetch, Heap, ReadStream, RelationPrefetch, RelationRead, RelationReadStream};
 use std::collections::{BinaryHeap, VecDeque, binary_heap, vec_deque};
 use std::iter::Chain;
+use std::marker::PhantomData;
 
 pub const WINDOW_SIZE: usize = 32;
 const _: () = assert!(WINDOW_SIZE > 0);
@@ -10,27 +12,42 @@ where
     Self::Item: Fetch,
 {
     type R: RelationRead;
+    type O: Operator;
     fn pop_if(
         &mut self,
         predicate: impl FnOnce(&Self::Item) -> bool,
-    ) -> Option<(Self::Item, Vec<<Self::R as RelationRead>::ReadGuard<'_>>)>;
+    ) -> Option<(
+        Self::Item,
+        Vec<<Self::R as RelationRead>::ReadGuard<'_>>,
+        Option<<Self::O as Operator>::Vector>,
+    )>;
 }
 
-pub struct PlainPrefetcher<R, H> {
+pub struct PlainPrefetcher<R, H, F, O> {
     relation: R,
     heap: H,
+    filter: F,
+    with_fetch: bool,
+    _phantom: PhantomData<O>,
 }
 
-impl<R, H: Heap> PlainPrefetcher<R, H> {
-    pub fn new(relation: R, vec: Vec<H::Item>) -> Self {
+impl<R, H: Heap, F: FnMut(&H::Item, bool) -> (bool, Option<O::Vector>), O: Operator>
+    PlainPrefetcher<R, H, F, O>
+{
+    pub fn new(relation: R, vec: Vec<H::Item>, filter: F, with_fetch: bool) -> Self {
         Self {
             relation,
             heap: Heap::make(vec),
+            filter,
+            with_fetch,
+            _phantom: PhantomData,
         }
     }
 }
 
-impl<R, H: Heap> IntoIterator for PlainPrefetcher<R, H> {
+impl<R, H: Heap, F: FnMut(&H::Item, bool) -> (bool, Option<O::Vector>), O: Operator> IntoIterator
+    for PlainPrefetcher<R, H, F, O>
+{
     type Item = H::Item;
 
     type IntoIter = H::IntoIter;
@@ -40,38 +57,53 @@ impl<R, H: Heap> IntoIterator for PlainPrefetcher<R, H> {
     }
 }
 
-impl<R: RelationRead, H: Heap> Prefetcher for PlainPrefetcher<R, H>
+impl<R: RelationRead, H: Heap, F: FnMut(&H::Item, bool) -> (bool, Option<O::Vector>), O: Operator>
+    Prefetcher for PlainPrefetcher<R, H, F, O>
 where
     H::Item: Fetch + Ord,
 {
     type R = R;
+    type O = O;
     fn pop_if<'s>(
         &'s mut self,
         predicate: impl FnOnce(&Self::Item) -> bool,
-    ) -> Option<(H::Item, Vec<R::ReadGuard<'s>>)> {
-        let e = self.heap.pop_if(predicate)?;
+    ) -> Option<(H::Item, Vec<R::ReadGuard<'s>>, Option<O::Vector>)> {
+        let (e, raw) = self.heap.pop_if_with(|m| {
+            let (filtered, raw) = (self.filter)(m, self.with_fetch);
+            (predicate(m) && filtered, raw)
+        })?;
         let list = e.fetch().iter().map(|&id| self.relation.read(id)).collect();
-        Some((e, list))
+        Some((e, list, raw))
     }
 }
 
-pub struct SimplePrefetcher<R, T> {
+pub struct SimplePrefetcher<R, T, F, O> {
     relation: R,
     window: VecDeque<T>,
     heap: BinaryHeap<T>,
+    filter: F,
+    with_fetch: bool,
+    _phantom: PhantomData<O>,
 }
 
-impl<R, T: Ord> SimplePrefetcher<R, T> {
-    pub fn new(relation: R, vec: Vec<T>) -> Self {
+impl<R, T: Ord, F: FnMut(&T, bool) -> (bool, Option<O::Vector>), O: Operator>
+    SimplePrefetcher<R, T, F, O>
+{
+    pub fn new(relation: R, vec: Vec<T>, filter: F, with_fetch: bool) -> Self {
         Self {
             relation,
             window: VecDeque::new(),
             heap: BinaryHeap::from(vec),
+            filter,
+            with_fetch,
+            _phantom: PhantomData,
         }
     }
 }
 
-impl<R, T> IntoIterator for SimplePrefetcher<R, T> {
+impl<R, T, F: FnMut(&T, bool) -> (bool, Option<O::Vector>), O: Operator> IntoIterator
+    for SimplePrefetcher<R, T, F, O>
+{
     type Item = T;
 
     type IntoIter = Chain<vec_deque::IntoIter<T>, binary_heap::IntoIter<T>>;
@@ -81,12 +113,19 @@ impl<R, T> IntoIterator for SimplePrefetcher<R, T> {
     }
 }
 
-impl<R: RelationRead + RelationPrefetch, T: Fetch + Ord> Prefetcher for SimplePrefetcher<R, T> {
+impl<
+    R: RelationRead + RelationPrefetch,
+    T: Fetch + Ord,
+    F: FnMut(&T, bool) -> (bool, Option<O::Vector>),
+    O: Operator,
+> Prefetcher for SimplePrefetcher<R, T, F, O>
+{
     type R = R;
+    type O = O;
     fn pop_if<'s>(
         &'s mut self,
         predicate: impl FnOnce(&Self::Item) -> bool,
-    ) -> Option<(T, Vec<R::ReadGuard<'s>>)> {
+    ) -> Option<(T, Vec<R::ReadGuard<'s>>, Option<O::Vector>)> {
         while self.window.len() < WINDOW_SIZE
             && let Some(e) = self.heap.pop()
         {
@@ -95,9 +134,12 @@ impl<R: RelationRead + RelationPrefetch, T: Fetch + Ord> Prefetcher for SimplePr
             }
             self.window.push_back(e);
         }
-        let e = vec_deque_pop_front_if(&mut self.window, predicate)?;
+        let (e, raw) = vec_deque_pop_front_if_with(&mut self.window, |m| {
+            let (filtered, raw) = (self.filter)(m, self.with_fetch);
+            (predicate(m) && filtered, raw)
+        })?;
         let list = e.fetch().iter().map(|&id| self.relation.read(id)).collect();
-        Some((e, list))
+        Some((e, list, raw))
     }
 }
 
@@ -110,22 +152,44 @@ impl<T: Ord> Iterator for StreamPrefetcherHeap<T> {
     }
 }
 
-pub struct StreamPrefetcher<'r, R, T>
+pub struct StreamPrefetcher<'r, R, T, F, O>
 where
     R: RelationReadStream + 'r,
     T: Fetch + Ord,
 {
     stream: R::ReadStream<'r, StreamPrefetcherHeap<T>>,
+    filter: F,
+    with_fetch: bool,
+    _phantom: PhantomData<O>,
 }
 
-impl<'r, R: RelationReadStream, T: Fetch + Ord> StreamPrefetcher<'r, R, T> {
-    pub fn new(relation: &'r R, vec: Vec<T>) -> Self {
+impl<
+    'r,
+    R: RelationReadStream,
+    T: Fetch + Ord,
+    F: FnMut(&T, bool) -> (bool, Option<O::Vector>),
+    O: Operator,
+> StreamPrefetcher<'r, R, T, F, O>
+{
+    pub fn new(relation: &'r R, vec: Vec<T>, filter: F, with_fetch: bool) -> Self {
         let stream = relation.read_stream(StreamPrefetcherHeap(BinaryHeap::from(vec)));
-        Self { stream }
+        Self {
+            stream,
+            filter,
+            with_fetch,
+            _phantom: PhantomData,
+        }
     }
 }
 
-impl<'r, R: RelationReadStream, T: Fetch + Ord> IntoIterator for StreamPrefetcher<'r, R, T> {
+impl<
+    'r,
+    R: RelationReadStream,
+    T: Fetch + Ord,
+    F: FnMut(&T, bool) -> (bool, Option<O::Vector>),
+    O: Operator,
+> IntoIterator for StreamPrefetcher<'r, R, T, F, O>
+{
     type Item = T;
 
     type IntoIter = <<R as RelationReadStream>::ReadStream<
@@ -138,19 +202,30 @@ impl<'r, R: RelationReadStream, T: Fetch + Ord> IntoIterator for StreamPrefetche
     }
 }
 
-impl<'r, R: RelationReadStream, T: Fetch + Ord> Prefetcher for StreamPrefetcher<'r, R, T> {
+impl<
+    'r,
+    R: RelationReadStream,
+    T: Fetch + Ord,
+    F: FnMut(&T, bool) -> (bool, Option<O::Vector>),
+    O: Operator,
+> Prefetcher for StreamPrefetcher<'r, R, T, F, O>
+{
     type R = R;
+    type O = O;
     fn pop_if<'s>(
         &'s mut self,
         predicate: impl FnOnce(&Self::Item) -> bool,
-    ) -> Option<(T, Vec<R::ReadGuard<'s>>)> {
-        self.stream.next_if(predicate)
+    ) -> Option<(T, Vec<R::ReadGuard<'s>>, Option<O::Vector>)> {
+        self.stream.next_if_with(|m| {
+            let (filtered, raw) = (self.filter)(m, self.with_fetch);
+            (predicate(m) && filtered, raw)
+        })
     }
 }
 
 // Emulate unstable library feature `vec_deque_pop_if`.
 // See https://github.com/rust-lang/rust/issues/135889.
-
+#[allow(dead_code)]
 fn vec_deque_pop_front_if<T>(
     this: &mut VecDeque<T>,
     predicate: impl FnOnce(&T) -> bool,
@@ -158,6 +233,19 @@ fn vec_deque_pop_front_if<T>(
     let first = this.front()?;
     if predicate(first) {
         this.pop_front()
+    } else {
+        None
+    }
+}
+
+fn vec_deque_pop_front_if_with<T, A>(
+    this: &mut VecDeque<T>,
+    predicate: impl FnOnce(&T) -> (bool, A),
+) -> Option<(T, A)> {
+    let first = this.front()?;
+    let (result, another) = predicate(first);
+    if result {
+        this.pop_front().map(|peek| (peek, another))
     } else {
         None
     }

--- a/crates/algorithm/src/rerank.rs
+++ b/crates/algorithm/src/rerank.rs
@@ -69,6 +69,7 @@ pub fn rerank_index<
 >(
     vector: O::Vector,
     prefetcher: P,
+    mut prefilter: impl FnMut(NonZero<u64>) -> bool,
 ) -> Reranker<
     T,
     impl FnMut(NonZero<u64>, Vec<<P::R as RelationRead>::ReadGuard<'_>>, u16) -> Option<Distance>,
@@ -78,6 +79,9 @@ pub fn rerank_index<
         prefetcher,
         cache: BinaryHeap::new(),
         f: id_4::<_, P::R, _, _, _>(move |payload, list, head| {
+            if !prefilter(payload) {
+                return None;
+            }
             vectors::read_for_h0_tuple::<P::R, O, _>(
                 head,
                 list.into_iter(),

--- a/crates/algorithm/src/search.rs
+++ b/crates/algorithm/src/search.rs
@@ -96,7 +96,7 @@ pub fn default_search<'b, R: RelationRead, O: Operator, P: Prefetcher<R = R, Ite
         let mut cache = BinaryHeap::<(Reverse<Distance>, _, _)>::new();
         let vector = vector.as_borrowed();
         std::iter::from_fn(move || {
-            while let Some(((Reverse(_), AlwaysEqual(&mut (first, head, ..))), list)) =
+            while let Some(((Reverse(_), AlwaysEqual(&mut (first, head, ..))), list, _)) =
                 heap.pop_if(|(d, ..)| Some(*d) > cache.peek().map(|(d, ..)| *d))
             {
                 if is_residual {
@@ -256,7 +256,7 @@ pub fn maxsim_search<'b, R: RelationRead, O: Operator, P: Prefetcher<R = R, Item
         let mut cache = BinaryHeap::<(Reverse<Distance>, _, _)>::new();
         let vector = vector.as_borrowed();
         std::iter::from_fn(move || {
-            while let Some(((Reverse(_), AlwaysEqual(&mut (first, head, ..))), list)) =
+            while let Some(((Reverse(_), AlwaysEqual(&mut (first, head, ..))), list, _)) =
                 heap.pop_if(|(d, ..)| Some(*d) > cache.peek().map(|(d, ..)| *d))
             {
                 if is_residual {

--- a/src/index/algorithm.rs
+++ b/src/index/algorithm.rs
@@ -295,49 +295,105 @@ pub fn insert(
 ) {
     use algorithm::{FastHeap, PlainPrefetcher};
     let bump = BumpAlloc::new();
-    let prefetch = {
-        let index = index.clone();
-        move |results| PlainPrefetcher::<_, FastHeap<_>>::new(index.clone(), results)
-    };
     match (vector, opfamily.distance_kind()) {
         (OwnedVector::Vecf32(vector), DistanceKind::L2) => {
             assert!(opfamily.vector_kind() == VectorKind::Vecf32);
-            algorithm::insert::<_, Op<VectOwned<f32>, L2>, _>(
+            let prefetch = {
+                let index = index.clone();
+                move |results| {
+                    PlainPrefetcher::<_, FastHeap<_>, _, Op<VectOwned<f32>, L2>>::new(
+                        index.clone(),
+                        results,
+                        |_, _| (true, None),
+                        false,
+                    )
+                }
+            };
+            let (list, head) =
+                algorithm::insert_vector::<_, Op<VectOwned<f32>, L2>>(&index, payload, &vector);
+            algorithm::insert_index::<_, Op<VectOwned<f32>, L2>, _>(
                 index,
                 payload,
                 RandomProject::project(vector.as_borrowed()),
                 &bump,
                 prefetch,
+                list,
+                head,
             )
         }
         (OwnedVector::Vecf32(vector), DistanceKind::Dot) => {
             assert!(opfamily.vector_kind() == VectorKind::Vecf32);
-            algorithm::insert::<_, Op<VectOwned<f32>, Dot>, _>(
+            let prefetch = {
+                let index = index.clone();
+                move |results| {
+                    PlainPrefetcher::<_, FastHeap<_>, _, Op<VectOwned<f32>, Dot>>::new(
+                        index.clone(),
+                        results,
+                        |_, _| (true, None),
+                        false,
+                    )
+                }
+            };
+            let (list, head) =
+                algorithm::insert_vector::<_, Op<VectOwned<f32>, Dot>>(&index, payload, &vector);
+            algorithm::insert_index::<_, Op<VectOwned<f32>, Dot>, _>(
                 index,
                 payload,
                 RandomProject::project(vector.as_borrowed()),
                 &bump,
                 prefetch,
+                list,
+                head,
             )
         }
         (OwnedVector::Vecf16(vector), DistanceKind::L2) => {
             assert!(opfamily.vector_kind() == VectorKind::Vecf16);
-            algorithm::insert::<_, Op<VectOwned<f16>, L2>, _>(
+            let prefetch = {
+                let index = index.clone();
+                move |results| {
+                    PlainPrefetcher::<_, FastHeap<_>, _, Op<VectOwned<f16>, L2>>::new(
+                        index.clone(),
+                        results,
+                        |_, _| (true, None),
+                        false,
+                    )
+                }
+            };
+            let (list, head) =
+                algorithm::insert_vector::<_, Op<VectOwned<f16>, L2>>(&index, payload, &vector);
+            algorithm::insert_index::<_, Op<VectOwned<f16>, L2>, _>(
                 index,
                 payload,
                 RandomProject::project(vector.as_borrowed()),
                 &bump,
                 prefetch,
+                list,
+                head,
             )
         }
         (OwnedVector::Vecf16(vector), DistanceKind::Dot) => {
             assert!(opfamily.vector_kind() == VectorKind::Vecf16);
-            algorithm::insert::<_, Op<VectOwned<f16>, Dot>, _>(
+            let prefetch = {
+                let index = index.clone();
+                move |results| {
+                    PlainPrefetcher::<_, FastHeap<_>, _, Op<VectOwned<f16>, Dot>>::new(
+                        index.clone(),
+                        results,
+                        |_, _| (true, None),
+                        false,
+                    )
+                }
+            };
+            let (list, head) =
+                algorithm::insert_vector::<_, Op<VectOwned<f16>, Dot>>(&index, payload, &vector);
+            algorithm::insert_index::<_, Op<VectOwned<f16>, Dot>, _>(
                 index,
                 payload,
                 RandomProject::project(vector.as_borrowed()),
                 &bump,
                 prefetch,
+                list,
+                head,
             )
         }
     }

--- a/src/index/am/mod.rs
+++ b/src/index/am/mod.rs
@@ -600,6 +600,43 @@ impl SearchFetcher for HeapFetcher {
             Some((&self.values, &self.is_nulls))
         }
     }
+
+    fn filter(&mut self, key: [u16; 3]) -> bool {
+        if !prererank_filtering() || self.hack.is_null() {
+            return true;
+        }
+        unsafe {
+            let mut ctid = key_to_ctid(key);
+            let table_am = (*self.heap_relation).rd_tableam;
+            let fetch_row_version = (*table_am)
+                .tuple_fetch_row_version
+                .expect("unsupported heap access method");
+            if !fetch_row_version(self.heap_relation, &mut ctid, self.snapshot, self.slot) {
+                return false;
+            }
+            if let Some(qual) = NonNull::new((*self.hack).ss.ps.qual) {
+                use pgrx::datum::FromDatum;
+                use pgrx::memcxt::PgMemoryContexts;
+                assert!(qual.as_ref().flags & pgrx::pg_sys::EEO_FLAG_IS_QUAL as u8 != 0);
+                let evalfunc = qual.as_ref().evalfunc.expect("no evalfunc for qual");
+                if !(*self.hack).ss.ps.ps_ExprContext.is_null() {
+                    let econtext = (*self.hack).ss.ps.ps_ExprContext;
+                    (*econtext).ecxt_scantuple = self.slot;
+                    pgrx::pg_sys::MemoryContextReset((*econtext).ecxt_per_tuple_memory);
+                    let result = PgMemoryContexts::For((*econtext).ecxt_per_tuple_memory)
+                        .switch_to(|_| {
+                            let mut is_null = true;
+                            let datum = evalfunc(qual.as_ptr(), econtext, &mut is_null);
+                            bool::from_datum(datum, is_null)
+                        });
+                    if result != Some(true) {
+                        return false;
+                    }
+                }
+            }
+            true
+        }
+    }
 }
 
 struct Index {

--- a/src/index/gucs.rs
+++ b/src/index/gucs.rs
@@ -22,7 +22,7 @@ static MAX_SCAN_TUPLES: GucSetting<i32> = GucSetting::<i32>::new(-1);
 static MAXSIM_REFINE: GucSetting<i32> = GucSetting::<i32>::new(0);
 static MAXSIM_THRESHOLD: GucSetting<i32> = GucSetting::<i32>::new(0);
 
-static PRERERANK_FILTERING: GucSetting<bool> = GucSetting::<bool>::new(false);
+static PREFILTER: GucSetting<bool> = GucSetting::<bool>::new(false);
 
 static IO_RERANK: GucSetting<Io> = GucSetting::<Io>::new(
     #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
@@ -89,10 +89,10 @@ pub fn init() {
         GucFlags::default(),
     );
     GucRegistry::define_bool_guc(
-        "vchordrq.prererank_filtering",
-        "`prererank_filtering` argument of vchordrq.",
-        "`prererank_filtering` argument of vchordrq.",
-        &PRERERANK_FILTERING,
+        "vchordrq.prefilter",
+        "`prefilter` argument of vchordrq.",
+        "`prefilter` argument of vchordrq.",
+        &PREFILTER,
         GucContext::Userset,
         GucFlags::default(),
     );
@@ -178,8 +178,8 @@ pub fn prewarm_dim() -> Vec<u32> {
     }
 }
 
-pub fn prererank_filtering() -> bool {
-    PRERERANK_FILTERING.get()
+pub fn enable_prefilter() -> bool {
+    PREFILTER.get()
 }
 
 pub fn io_rerank() -> SearchIo {

--- a/src/index/scanners/default.rs
+++ b/src/index/scanners/default.rs
@@ -1,7 +1,7 @@
 use super::{SearchBuilder, SearchFetcher, SearchIo, SearchOptions};
 use crate::index::algorithm::RandomProject;
 use crate::index::am::pointer_to_kv;
-use crate::index::gucs::prererank_filtering;
+use crate::index::gucs::enable_prefilter;
 use crate::index::opclass::{Opfamily, Sphere};
 use algorithm::operator::{Dot, L2, Op, Operator};
 use algorithm::types::{DistanceKind, OwnedVector, VectorKind};
@@ -81,42 +81,49 @@ impl SearchBuilder for DefaultBuilder {
         let Some(vector) = vector else {
             return Box::new(std::iter::empty()) as Box<dyn Iterator<Item = (f32, [u16; 3], bool)>>;
         };
-        let iter: Box<dyn Iterator<Item = (f32, NonZero<u64>)>> =
-            match (opfamily.vector_kind(), opfamily.distance_kind()) {
-                (VectorKind::Vecf32, DistanceKind::L2) => {
-                    let method = how(relation.clone());
-                    let original_vector = if let OwnedVector::Vecf32(vector) = vector {
-                        vector
-                    } else {
-                        unreachable!()
-                    };
-                    let vector = RandomProject::project(original_vector.as_borrowed());
-                    let results = default_search::<_, Op<VectOwned<f32>, L2>, _>(
-                        relation.clone(),
-                        vector.clone(),
-                        options.probes,
-                        options.epsilon,
-                        bump,
-                        {
-                            let index = relation.clone();
-                            move |results| {
-                                PlainPrefetcher::<_, BinaryHeap<_>>::new(index.clone(), results)
-                            }
-                        },
-                    );
-                    match method {
-                        RerankMethod::Index => rerank_index_wrapper::<Op<VectOwned<f32>, L2>>(
-                            vector,
-                            relation,
-                            fetcher,
-                            opfamily,
-                            results,
-                            options.io_rerank,
-                        ),
-                        RerankMethod::Heap => {
-                            let fetch = move |payload| {
-                                let (key, _) = pointer_to_kv(payload);
-                                let (datums, is_nulls) = fetcher.fetch(key)?;
+        // let prefilter = move |result: &Result| {
+        //     if !enable_prefilter() {
+        //         return true;
+        //     }
+        //     let (key, _) = pointer_to_kv(result.1.0.0);
+        //     fetcher.filter(key)
+        // };
+        let iter: Box<dyn Iterator<Item = (f32, NonZero<u64>)>> = match (
+            opfamily.vector_kind(),
+            opfamily.distance_kind(),
+        ) {
+            (VectorKind::Vecf32, DistanceKind::L2) => {
+                let original_vector = if let OwnedVector::Vecf32(vector) = vector {
+                    vector
+                } else {
+                    unreachable!()
+                };
+                let vector = RandomProject::project(original_vector.as_borrowed());
+                let results = default_search::<_, Op<VectOwned<f32>, L2>, _>(
+                    relation.clone(),
+                    vector.clone(),
+                    options.probes,
+                    options.epsilon,
+                    bump,
+                    {
+                        let index = relation.clone();
+                        move |results| {
+                            PlainPrefetcher::<_, BinaryHeap<_>, _, Op<VectOwned<f32>, L2>>::new(
+                                index.clone(),
+                                results,
+                                |_, _| (true, None),
+                                false,
+                            )
+                        }
+                    },
+                );
+                let prefilter = move |result: &Result, with_fetch: bool| {
+                    let (key, _) = pointer_to_kv(result.1.0.0);
+                    match (enable_prefilter(), with_fetch) {
+                        (false, false) => (true, None),
+                        (true, false) => (fetcher.filter_only(key), None),
+                        (_, true) => match fetcher.filter_fetch(key) {
+                            Some((datums, is_nulls)) => {
                                 let datum = (!is_nulls[0]).then_some(datums[0]);
                                 let maybe_vector =
                                     unsafe { datum.and_then(|x| opfamily.input_vector(x)) };
@@ -126,53 +133,55 @@ impl SearchBuilder for DefaultBuilder {
                                 } else {
                                     unreachable!()
                                 };
-                                Some(raw)
-                            };
-                            rerank_heap_wrapper::<Op<VectOwned<f32>, L2>>(
-                                original_vector,
-                                relation,
-                                fetch,
-                                opfamily,
+                                (true, Some(raw))
+                            }
+                            None => (false, None),
+                        },
+                    }
+                };
+                let method = how(relation.clone());
+                rerank_wrapper::<Op<VectOwned<f32>, L2>>(
+                    original_vector,
+                    relation,
+                    prefilter,
+                    opfamily,
+                    results,
+                    method,
+                    options.io_rerank,
+                )
+            }
+            (VectorKind::Vecf32, DistanceKind::Dot) => {
+                let original_vector = if let OwnedVector::Vecf32(vector) = vector {
+                    vector
+                } else {
+                    unreachable!()
+                };
+                let vector = RandomProject::project(original_vector.as_borrowed());
+                let results = default_search::<_, Op<VectOwned<f32>, Dot>, _>(
+                    relation.clone(),
+                    vector.clone(),
+                    options.probes,
+                    options.epsilon,
+                    bump,
+                    {
+                        let index = relation.clone();
+                        move |results| {
+                            PlainPrefetcher::<_, BinaryHeap<_>, _, Op<VectOwned<f32>, Dot>>::new(
+                                index.clone(),
                                 results,
-                                options.io_rerank,
+                                |_, _| (true, None),
+                                false,
                             )
                         }
-                    }
-                }
-                (VectorKind::Vecf32, DistanceKind::Dot) => {
-                    let original_vector = if let OwnedVector::Vecf32(vector) = vector {
-                        vector
-                    } else {
-                        unreachable!()
-                    };
-                    let vector = RandomProject::project(original_vector.as_borrowed());
-                    let results = default_search::<_, Op<VectOwned<f32>, Dot>, _>(
-                        relation.clone(),
-                        vector.clone(),
-                        options.probes,
-                        options.epsilon,
-                        bump,
-                        {
-                            let index = relation.clone();
-                            move |results| {
-                                PlainPrefetcher::<_, BinaryHeap<_>>::new(index.clone(), results)
-                            }
-                        },
-                    );
-                    let method = how(relation.clone());
-                    match method {
-                        RerankMethod::Index => rerank_index_wrapper::<Op<VectOwned<f32>, Dot>>(
-                            vector,
-                            relation,
-                            fetcher,
-                            opfamily,
-                            results,
-                            options.io_rerank,
-                        ),
-                        RerankMethod::Heap => {
-                            let fetch = move |payload| {
-                                let (key, _) = pointer_to_kv(payload);
-                                let (datums, is_nulls) = fetcher.fetch(key)?;
+                    },
+                );
+                let prefilter = move |result: &Result, with_fetch: bool| {
+                    let (key, _) = pointer_to_kv(result.1.0.0);
+                    match (enable_prefilter(), with_fetch) {
+                        (false, false) => (true, None),
+                        (true, false) => (fetcher.filter_only(key), None),
+                        (_, true) => match fetcher.filter_fetch(key) {
+                            Some((datums, is_nulls)) => {
                                 let datum = (!is_nulls[0]).then_some(datums[0]);
                                 let maybe_vector =
                                     unsafe { datum.and_then(|x| opfamily.input_vector(x)) };
@@ -182,53 +191,55 @@ impl SearchBuilder for DefaultBuilder {
                                 } else {
                                     unreachable!()
                                 };
-                                Some(raw)
-                            };
-                            rerank_heap_wrapper::<Op<VectOwned<f32>, Dot>>(
-                                original_vector,
-                                relation,
-                                fetch,
-                                opfamily,
+                                (true, Some(raw))
+                            }
+                            None => (false, None),
+                        },
+                    }
+                };
+                let method = how(relation.clone());
+                rerank_wrapper::<Op<VectOwned<f32>, Dot>>(
+                    original_vector,
+                    relation,
+                    prefilter,
+                    opfamily,
+                    results,
+                    method,
+                    options.io_rerank,
+                )
+            }
+            (VectorKind::Vecf16, DistanceKind::L2) => {
+                let original_vector = if let OwnedVector::Vecf16(vector) = vector {
+                    vector
+                } else {
+                    unreachable!()
+                };
+                let vector = RandomProject::project(original_vector.as_borrowed());
+                let results = default_search::<_, Op<VectOwned<f16>, L2>, _>(
+                    relation.clone(),
+                    vector.clone(),
+                    options.probes,
+                    options.epsilon,
+                    bump,
+                    {
+                        let index = relation.clone();
+                        move |results| {
+                            PlainPrefetcher::<_, BinaryHeap<_>, _, Op<VectOwned<f16>, L2>>::new(
+                                index.clone(),
                                 results,
-                                options.io_rerank,
+                                |_, _| (true, None),
+                                false,
                             )
                         }
-                    }
-                }
-                (VectorKind::Vecf16, DistanceKind::L2) => {
-                    let original_vector = if let OwnedVector::Vecf16(vector) = vector {
-                        vector
-                    } else {
-                        unreachable!()
-                    };
-                    let vector = RandomProject::project(original_vector.as_borrowed());
-                    let results = default_search::<_, Op<VectOwned<f16>, L2>, _>(
-                        relation.clone(),
-                        vector.clone(),
-                        options.probes,
-                        options.epsilon,
-                        bump,
-                        {
-                            let index = relation.clone();
-                            move |results| {
-                                PlainPrefetcher::<_, BinaryHeap<_>>::new(index.clone(), results)
-                            }
-                        },
-                    );
-                    let method = how(relation.clone());
-                    match method {
-                        RerankMethod::Index => rerank_index_wrapper::<Op<VectOwned<f16>, L2>>(
-                            vector,
-                            relation,
-                            fetcher,
-                            opfamily,
-                            results,
-                            options.io_rerank,
-                        ),
-                        RerankMethod::Heap => {
-                            let fetch = move |payload| {
-                                let (key, _) = pointer_to_kv(payload);
-                                let (datums, is_nulls) = fetcher.fetch(key)?;
+                    },
+                );
+                let prefilter = move |result: &Result, with_fetch: bool| {
+                    let (key, _) = pointer_to_kv(result.1.0.0);
+                    match (enable_prefilter(), with_fetch) {
+                        (false, false) => (true, None),
+                        (true, false) => (fetcher.filter_only(key), None),
+                        (_, true) => match fetcher.filter_fetch(key) {
+                            Some((datums, is_nulls)) => {
                                 let datum = (!is_nulls[0]).then_some(datums[0]);
                                 let maybe_vector =
                                     unsafe { datum.and_then(|x| opfamily.input_vector(x)) };
@@ -238,53 +249,55 @@ impl SearchBuilder for DefaultBuilder {
                                 } else {
                                     unreachable!()
                                 };
-                                Some(raw)
-                            };
-                            rerank_heap_wrapper::<Op<VectOwned<f16>, L2>>(
-                                original_vector,
-                                relation,
-                                fetch,
-                                opfamily,
+                                (true, Some(raw))
+                            }
+                            None => (false, None),
+                        },
+                    }
+                };
+                let method = how(relation.clone());
+                rerank_wrapper::<Op<VectOwned<f16>, L2>>(
+                    original_vector,
+                    relation,
+                    prefilter,
+                    opfamily,
+                    results,
+                    method,
+                    options.io_rerank,
+                )
+            }
+            (VectorKind::Vecf16, DistanceKind::Dot) => {
+                let original_vector = if let OwnedVector::Vecf16(vector) = vector {
+                    vector
+                } else {
+                    unreachable!()
+                };
+                let vector = RandomProject::project(original_vector.as_borrowed());
+                let results = default_search::<_, Op<VectOwned<f16>, Dot>, _>(
+                    relation.clone(),
+                    vector.clone(),
+                    options.probes,
+                    options.epsilon,
+                    bump,
+                    {
+                        let index = relation.clone();
+                        move |results| {
+                            PlainPrefetcher::<_, BinaryHeap<_>, _, Op<VectOwned<f16>, Dot>>::new(
+                                index.clone(),
                                 results,
-                                options.io_rerank,
+                                |_, _| (true, None),
+                                false,
                             )
                         }
-                    }
-                }
-                (VectorKind::Vecf16, DistanceKind::Dot) => {
-                    let original_vector = if let OwnedVector::Vecf16(vector) = vector {
-                        vector
-                    } else {
-                        unreachable!()
-                    };
-                    let vector = RandomProject::project(original_vector.as_borrowed());
-                    let results = default_search::<_, Op<VectOwned<f16>, Dot>, _>(
-                        relation.clone(),
-                        vector.clone(),
-                        options.probes,
-                        options.epsilon,
-                        bump,
-                        {
-                            let index = relation.clone();
-                            move |results| {
-                                PlainPrefetcher::<_, BinaryHeap<_>>::new(index.clone(), results)
-                            }
-                        },
-                    );
-                    let method = how(relation.clone());
-                    match method {
-                        RerankMethod::Index => rerank_index_wrapper::<Op<VectOwned<f16>, Dot>>(
-                            vector,
-                            relation,
-                            fetcher,
-                            opfamily,
-                            results,
-                            options.io_rerank,
-                        ),
-                        RerankMethod::Heap => {
-                            let fetch = move |payload| {
-                                let (key, _) = pointer_to_kv(payload);
-                                let (datums, is_nulls) = fetcher.fetch(key)?;
+                    },
+                );
+                let prefilter = move |result: &Result, with_fetch: bool| {
+                    let (key, _) = pointer_to_kv(result.1.0.0);
+                    match (enable_prefilter(), with_fetch) {
+                        (false, false) => (true, None),
+                        (true, false) => (fetcher.filter_only(key), None),
+                        (_, true) => match fetcher.filter_fetch(key) {
+                            Some((datums, is_nulls)) => {
                                 let datum = (!is_nulls[0]).then_some(datums[0]);
                                 let maybe_vector =
                                     unsafe { datum.and_then(|x| opfamily.input_vector(x)) };
@@ -294,20 +307,24 @@ impl SearchBuilder for DefaultBuilder {
                                 } else {
                                     unreachable!()
                                 };
-                                Some(raw)
-                            };
-                            rerank_heap_wrapper::<Op<VectOwned<f16>, Dot>>(
-                                original_vector,
-                                relation,
-                                fetch,
-                                opfamily,
-                                results,
-                                options.io_rerank,
-                            )
-                        }
+                                (true, Some(raw))
+                            }
+                            None => (false, None),
+                        },
                     }
-                }
-            };
+                };
+                let method = how(relation.clone());
+                rerank_wrapper::<Op<VectOwned<f16>, Dot>>(
+                    original_vector,
+                    relation,
+                    prefilter,
+                    opfamily,
+                    results,
+                    method,
+                    options.io_rerank,
+                )
+            }
+        };
         let iter = if let Some(threshold) = threshold {
             Box::new(iter.take_while(move |(x, _)| *x < threshold))
         } else {
@@ -328,75 +345,66 @@ impl SearchBuilder for DefaultBuilder {
 type Extra<'b> = &'b mut (NonZero<u64>, u16, &'b mut [u32]);
 type Result<'b> = ((Reverse<Distance>, AlwaysEqual<()>), AlwaysEqual<Extra<'b>>);
 
-#[inline(always)]
-fn rerank_index_wrapper<'a, O: Operator>(
+#[allow(clippy::too_many_arguments)]
+fn rerank_wrapper<'a, O: Operator>(
     vector: O::Vector,
     relation: &'a (impl RelationPrefetch + RelationReadStream),
-    mut fetcher: impl SearchFetcher + 'a,
+    prefilter: impl FnMut(&Result, bool) -> (bool, Option<O::Vector>) + 'a,
     opfamily: Opfamily,
     results: Vec<Result<'a>>,
+    method: RerankMethod,
     io_rerank: SearchIo,
 ) -> Box<dyn Iterator<Item = (f32, NonZero<u64>)> + 'a> {
-    let prefilter = move |payload| {
-        if !prererank_filtering() {
-            return true;
-        }
-        let (key, _) = pointer_to_kv(payload);
-        fetcher.filter(key)
-    };
-    match io_rerank {
-        SearchIo::ReadBuffer => {
-            let prefetcher = PlainPrefetcher::<_, BinaryHeap<_>>::new(relation.clone(), results);
+    match (method, io_rerank) {
+        (RerankMethod::Index, SearchIo::ReadBuffer) => {
+            let prefetcher = PlainPrefetcher::<_, BinaryHeap<_>, _, O>::new(
+                relation.clone(),
+                results,
+                prefilter,
+                false,
+            );
             Box::new(
-                rerank_index::<O, _, _>(vector, prefetcher, prefilter)
+                rerank_index::<O, _, _>(vector, prefetcher)
                     .map(move |(distance, payload)| (opfamily.output(distance), payload)),
             )
         }
-        SearchIo::PrefetchBuffer => {
-            let prefetcher = SimplePrefetcher::new(relation.clone(), results);
+        (RerankMethod::Index, SearchIo::PrefetchBuffer) => {
+            let prefetcher = SimplePrefetcher::new(relation.clone(), results, prefilter, false);
             Box::new(
-                rerank_index::<O, _, _>(vector, prefetcher, prefilter)
+                rerank_index::<O, _, _>(vector, prefetcher)
                     .map(move |(distance, payload)| (opfamily.output(distance), payload)),
             )
         }
-        SearchIo::ReadStream => {
-            let prefetcher = StreamPrefetcher::new(relation, results);
+        (RerankMethod::Index, SearchIo::ReadStream) => {
+            let prefetcher = StreamPrefetcher::new(relation, results, prefilter, false);
             Box::new(
-                rerank_index::<O, _, _>(vector, prefetcher, prefilter)
+                rerank_index::<O, _, _>(vector, prefetcher)
                     .map(move |(distance, payload)| (opfamily.output(distance), payload)),
             )
         }
-    }
-}
-
-#[inline(always)]
-fn rerank_heap_wrapper<'a, O: Operator>(
-    vector: O::Vector,
-    relation: &'a (impl RelationPrefetch + RelationReadStream),
-    fetch: impl FnMut(NonZero<u64>) -> Option<O::Vector> + 'a,
-    opfamily: Opfamily,
-    results: Vec<Result<'a>>,
-    io_rerank: SearchIo,
-) -> Box<dyn Iterator<Item = (f32, NonZero<u64>)> + 'a> {
-    match io_rerank {
-        SearchIo::ReadBuffer => {
-            let prefetcher = PlainPrefetcher::<_, BinaryHeap<_>>::new(relation.clone(), results);
+        (RerankMethod::Heap, SearchIo::ReadBuffer) => {
+            let prefetcher = PlainPrefetcher::<_, BinaryHeap<_>, _, O>::new(
+                relation.clone(),
+                results,
+                prefilter,
+                true,
+            );
             Box::new(
-                rerank_heap::<O, _, _>(vector, prefetcher, fetch)
+                rerank_heap::<O, _, _>(vector, prefetcher)
                     .map(move |(distance, payload)| (opfamily.output(distance), payload)),
             )
         }
-        SearchIo::PrefetchBuffer => {
-            let prefetcher = SimplePrefetcher::new(relation.clone(), results);
+        (RerankMethod::Heap, SearchIo::PrefetchBuffer) => {
+            let prefetcher = SimplePrefetcher::new(relation.clone(), results, prefilter, true);
             Box::new(
-                rerank_heap::<O, _, _>(vector, prefetcher, fetch)
+                rerank_heap::<O, _, _>(vector, prefetcher)
                     .map(move |(distance, payload)| (opfamily.output(distance), payload)),
             )
         }
-        SearchIo::ReadStream => {
-            let prefetcher = StreamPrefetcher::new(relation, results);
+        (RerankMethod::Heap, SearchIo::ReadStream) => {
+            let prefetcher = StreamPrefetcher::new(relation, results, prefilter, true);
             Box::new(
-                rerank_heap::<O, _, _>(vector, prefetcher, fetch)
+                rerank_heap::<O, _, _>(vector, prefetcher)
                     .map(move |(distance, payload)| (opfamily.output(distance), payload)),
             )
         }

--- a/src/index/scanners/maxsim.rs
+++ b/src/index/scanners/maxsim.rs
@@ -77,7 +77,7 @@ impl SearchBuilder for MaxsimBuilder {
             _,
             AlwaysEqual<&mut (NonZero<u64>, _, _)>,
         )| (rough, payload);
-        let fake_prefilter = |_| true;
+        let default_prefilter = |_| true;
         let iter: Box<dyn Iterator<Item = _>> = match opfamily.vector_kind() {
             VectorKind::Vecf32 => {
                 type Op = operator::Op<VectOwned<f32>, Dot>;
@@ -120,7 +120,7 @@ impl SearchBuilder for MaxsimBuilder {
                                 let mut reranker = rerank_index::<Op, _, _>(
                                     vector.clone(),
                                     prefetcher,
-                                    fake_prefilter,
+                                    default_prefilter,
                                 );
                                 accu_set.extend(reranker.by_ref().take(maxsim_refine as _));
                                 let (rough_iter, accu_iter) = reranker.finish();
@@ -132,7 +132,7 @@ impl SearchBuilder for MaxsimBuilder {
                                 let mut reranker = rerank_index::<Op, _, _>(
                                     vector.clone(),
                                     prefetcher,
-                                    fake_prefilter,
+                                    default_prefilter,
                                 );
                                 accu_set.extend(reranker.by_ref().take(maxsim_refine as _));
                                 let (rough_iter, accu_iter) = reranker.finish();
@@ -144,7 +144,7 @@ impl SearchBuilder for MaxsimBuilder {
                                 let mut reranker = rerank_index::<Op, _, _>(
                                     vector.clone(),
                                     prefetcher,
-                                    fake_prefilter,
+                                    default_prefilter,
                                 );
                                 accu_set.extend(reranker.by_ref().take(maxsim_refine as _));
                                 let (rough_iter, accu_iter) = reranker.finish();
@@ -200,7 +200,7 @@ impl SearchBuilder for MaxsimBuilder {
                                 let mut reranker = rerank_index::<Op, _, _>(
                                     vector.clone(),
                                     prefetcher,
-                                    fake_prefilter,
+                                    default_prefilter,
                                 );
                                 accu_set.extend(reranker.by_ref().take(maxsim_refine as _));
                                 let (rough_iter, accu_iter) = reranker.finish();
@@ -212,7 +212,7 @@ impl SearchBuilder for MaxsimBuilder {
                                 let mut reranker = rerank_index::<Op, _, _>(
                                     vector.clone(),
                                     prefetcher,
-                                    fake_prefilter,
+                                    default_prefilter,
                                 );
                                 accu_set.extend(reranker.by_ref().take(maxsim_refine as _));
                                 let (rough_iter, accu_iter) = reranker.finish();
@@ -224,7 +224,7 @@ impl SearchBuilder for MaxsimBuilder {
                                 let mut reranker = rerank_index::<Op, _, _>(
                                     vector.clone(),
                                     prefetcher,
-                                    fake_prefilter,
+                                    default_prefilter,
                                 );
                                 accu_set.extend(reranker.by_ref().take(maxsim_refine as _));
                                 let (rough_iter, accu_iter) = reranker.finish();

--- a/src/index/scanners/maxsim.rs
+++ b/src/index/scanners/maxsim.rs
@@ -77,6 +77,7 @@ impl SearchBuilder for MaxsimBuilder {
             _,
             AlwaysEqual<&mut (NonZero<u64>, _, _)>,
         )| (rough, payload);
+        let fake_prefilter = |_| true;
         let iter: Box<dyn Iterator<Item = _>> = match opfamily.vector_kind() {
             VectorKind::Vecf32 => {
                 type Op = operator::Op<VectOwned<f32>, Dot>;
@@ -116,8 +117,11 @@ impl SearchBuilder for MaxsimBuilder {
                                     relation.clone(),
                                     results,
                                 );
-                                let mut reranker =
-                                    rerank_index::<Op, _, _>(vector.clone(), prefetcher);
+                                let mut reranker = rerank_index::<Op, _, _>(
+                                    vector.clone(),
+                                    prefetcher,
+                                    fake_prefilter,
+                                );
                                 accu_set.extend(reranker.by_ref().take(maxsim_refine as _));
                                 let (rough_iter, accu_iter) = reranker.finish();
                                 accu_set.extend(accu_iter.map(accu_map));
@@ -125,8 +129,11 @@ impl SearchBuilder for MaxsimBuilder {
                             }
                             SearchIo::PrefetchBuffer => {
                                 let prefetcher = SimplePrefetcher::new(relation.clone(), results);
-                                let mut reranker =
-                                    rerank_index::<Op, _, _>(vector.clone(), prefetcher);
+                                let mut reranker = rerank_index::<Op, _, _>(
+                                    vector.clone(),
+                                    prefetcher,
+                                    fake_prefilter,
+                                );
                                 accu_set.extend(reranker.by_ref().take(maxsim_refine as _));
                                 let (rough_iter, accu_iter) = reranker.finish();
                                 accu_set.extend(accu_iter.map(accu_map));
@@ -134,8 +141,11 @@ impl SearchBuilder for MaxsimBuilder {
                             }
                             SearchIo::ReadStream => {
                                 let prefetcher = StreamPrefetcher::new(relation, results);
-                                let mut reranker =
-                                    rerank_index::<Op, _, _>(vector.clone(), prefetcher);
+                                let mut reranker = rerank_index::<Op, _, _>(
+                                    vector.clone(),
+                                    prefetcher,
+                                    fake_prefilter,
+                                );
                                 accu_set.extend(reranker.by_ref().take(maxsim_refine as _));
                                 let (rough_iter, accu_iter) = reranker.finish();
                                 accu_set.extend(accu_iter.map(accu_map));
@@ -187,8 +197,11 @@ impl SearchBuilder for MaxsimBuilder {
                                     relation.clone(),
                                     results,
                                 );
-                                let mut reranker =
-                                    rerank_index::<Op, _, _>(vector.clone(), prefetcher);
+                                let mut reranker = rerank_index::<Op, _, _>(
+                                    vector.clone(),
+                                    prefetcher,
+                                    fake_prefilter,
+                                );
                                 accu_set.extend(reranker.by_ref().take(maxsim_refine as _));
                                 let (rough_iter, accu_iter) = reranker.finish();
                                 accu_set.extend(accu_iter.map(accu_map));
@@ -196,8 +209,11 @@ impl SearchBuilder for MaxsimBuilder {
                             }
                             SearchIo::PrefetchBuffer => {
                                 let prefetcher = SimplePrefetcher::new(relation.clone(), results);
-                                let mut reranker =
-                                    rerank_index::<Op, _, _>(vector.clone(), prefetcher);
+                                let mut reranker = rerank_index::<Op, _, _>(
+                                    vector.clone(),
+                                    prefetcher,
+                                    fake_prefilter,
+                                );
                                 accu_set.extend(reranker.by_ref().take(maxsim_refine as _));
                                 let (rough_iter, accu_iter) = reranker.finish();
                                 accu_set.extend(accu_iter.map(accu_map));
@@ -205,8 +221,11 @@ impl SearchBuilder for MaxsimBuilder {
                             }
                             SearchIo::ReadStream => {
                                 let prefetcher = StreamPrefetcher::new(relation, results);
-                                let mut reranker =
-                                    rerank_index::<Op, _, _>(vector.clone(), prefetcher);
+                                let mut reranker = rerank_index::<Op, _, _>(
+                                    vector.clone(),
+                                    prefetcher,
+                                    fake_prefilter,
+                                );
                                 accu_set.extend(reranker.by_ref().take(maxsim_refine as _));
                                 let (rough_iter, accu_iter) = reranker.finish();
                                 accu_set.extend(accu_iter.map(accu_map));

--- a/src/index/scanners/maxsim.rs
+++ b/src/index/scanners/maxsim.rs
@@ -77,7 +77,6 @@ impl SearchBuilder for MaxsimBuilder {
             _,
             AlwaysEqual<&mut (NonZero<u64>, _, _)>,
         )| (rough, payload);
-        let default_prefilter = |_| true;
         let iter: Box<dyn Iterator<Item = _>> = match opfamily.vector_kind() {
             VectorKind::Vecf32 => {
                 type Op = operator::Op<VectOwned<f32>, Dot>;
@@ -105,7 +104,12 @@ impl SearchBuilder for MaxsimBuilder {
                         {
                             let index = relation.clone();
                             move |results| {
-                                PlainPrefetcher::<_, BinaryHeap<_>>::new(index.clone(), results)
+                                PlainPrefetcher::<_, BinaryHeap<_>, _, Op>::new(
+                                    index.clone(),
+                                    results,
+                                    |_, _| (true, None),
+                                    false,
+                                )
                             }
                         },
                     );
@@ -113,39 +117,42 @@ impl SearchBuilder for MaxsimBuilder {
                     if maxsim_refine != 0 && !results.is_empty() {
                         match options.io_rerank {
                             SearchIo::ReadBuffer => {
-                                let prefetcher = PlainPrefetcher::<_, BinaryHeap<_>>::new(
+                                let prefetcher = PlainPrefetcher::<_, BinaryHeap<_>, _, _>::new(
                                     relation.clone(),
                                     results,
+                                    |_, _| (true, None),
+                                    false,
                                 );
-                                let mut reranker = rerank_index::<Op, _, _>(
-                                    vector.clone(),
-                                    prefetcher,
-                                    default_prefilter,
-                                );
+                                let mut reranker =
+                                    rerank_index::<Op, _, _>(vector.clone(), prefetcher);
                                 accu_set.extend(reranker.by_ref().take(maxsim_refine as _));
                                 let (rough_iter, accu_iter) = reranker.finish();
                                 accu_set.extend(accu_iter.map(accu_map));
                                 rough_set.extend(rough_iter.into_iter().map(rough_map));
                             }
                             SearchIo::PrefetchBuffer => {
-                                let prefetcher = SimplePrefetcher::new(relation.clone(), results);
-                                let mut reranker = rerank_index::<Op, _, _>(
-                                    vector.clone(),
-                                    prefetcher,
-                                    default_prefilter,
+                                let prefetcher = SimplePrefetcher::new(
+                                    relation.clone(),
+                                    results,
+                                    |_, _| (true, None),
+                                    false,
                                 );
+                                let mut reranker =
+                                    rerank_index::<Op, _, _>(vector.clone(), prefetcher);
                                 accu_set.extend(reranker.by_ref().take(maxsim_refine as _));
                                 let (rough_iter, accu_iter) = reranker.finish();
                                 accu_set.extend(accu_iter.map(accu_map));
                                 rough_set.extend(rough_iter.into_iter().map(rough_map));
                             }
                             SearchIo::ReadStream => {
-                                let prefetcher = StreamPrefetcher::new(relation, results);
-                                let mut reranker = rerank_index::<Op, _, _>(
-                                    vector.clone(),
-                                    prefetcher,
-                                    default_prefilter,
+                                let prefetcher = StreamPrefetcher::new(
+                                    relation,
+                                    results,
+                                    |_, _| (true, None),
+                                    false,
                                 );
+                                let mut reranker =
+                                    rerank_index::<Op, _, _>(vector.clone(), prefetcher);
                                 accu_set.extend(reranker.by_ref().take(maxsim_refine as _));
                                 let (rough_iter, accu_iter) = reranker.finish();
                                 accu_set.extend(accu_iter.map(accu_map));
@@ -185,7 +192,12 @@ impl SearchBuilder for MaxsimBuilder {
                         {
                             let index = relation.clone();
                             move |results| {
-                                PlainPrefetcher::<_, BinaryHeap<_>>::new(index.clone(), results)
+                                PlainPrefetcher::<_, BinaryHeap<_>, _, Op>::new(
+                                    index.clone(),
+                                    results,
+                                    |_, _| (true, None),
+                                    false,
+                                )
                             }
                         },
                     );
@@ -193,39 +205,42 @@ impl SearchBuilder for MaxsimBuilder {
                     if maxsim_refine != 0 && !results.is_empty() {
                         match options.io_rerank {
                             SearchIo::ReadBuffer => {
-                                let prefetcher = PlainPrefetcher::<_, BinaryHeap<_>>::new(
+                                let prefetcher = PlainPrefetcher::<_, BinaryHeap<_>, _, _>::new(
                                     relation.clone(),
                                     results,
+                                    |_, _| (true, None),
+                                    false,
                                 );
-                                let mut reranker = rerank_index::<Op, _, _>(
-                                    vector.clone(),
-                                    prefetcher,
-                                    default_prefilter,
-                                );
+                                let mut reranker =
+                                    rerank_index::<Op, _, _>(vector.clone(), prefetcher);
                                 accu_set.extend(reranker.by_ref().take(maxsim_refine as _));
                                 let (rough_iter, accu_iter) = reranker.finish();
                                 accu_set.extend(accu_iter.map(accu_map));
                                 rough_set.extend(rough_iter.into_iter().map(rough_map));
                             }
                             SearchIo::PrefetchBuffer => {
-                                let prefetcher = SimplePrefetcher::new(relation.clone(), results);
-                                let mut reranker = rerank_index::<Op, _, _>(
-                                    vector.clone(),
-                                    prefetcher,
-                                    default_prefilter,
+                                let prefetcher = SimplePrefetcher::new(
+                                    relation.clone(),
+                                    results,
+                                    |_, _| (true, None),
+                                    false,
                                 );
+                                let mut reranker =
+                                    rerank_index::<Op, _, _>(vector.clone(), prefetcher);
                                 accu_set.extend(reranker.by_ref().take(maxsim_refine as _));
                                 let (rough_iter, accu_iter) = reranker.finish();
                                 accu_set.extend(accu_iter.map(accu_map));
                                 rough_set.extend(rough_iter.into_iter().map(rough_map));
                             }
                             SearchIo::ReadStream => {
-                                let prefetcher = StreamPrefetcher::new(relation, results);
-                                let mut reranker = rerank_index::<Op, _, _>(
-                                    vector.clone(),
-                                    prefetcher,
-                                    default_prefilter,
+                                let prefetcher = StreamPrefetcher::new(
+                                    relation,
+                                    results,
+                                    |_, _| (true, None),
+                                    false,
                                 );
+                                let mut reranker =
+                                    rerank_index::<Op, _, _>(vector.clone(), prefetcher);
                                 accu_set.extend(reranker.by_ref().take(maxsim_refine as _));
                                 let (rough_iter, accu_iter) = reranker.finish();
                                 accu_set.extend(accu_iter.map(accu_map));

--- a/src/index/scanners/mod.rs
+++ b/src/index/scanners/mod.rs
@@ -45,15 +45,15 @@ pub trait SearchBuilder: 'static {
 }
 
 pub trait SearchFetcher {
-    fn fetch(&mut self, ctid: [u16; 3]) -> Option<(&[Datum; 32], &[bool; 32])>;
-    fn filter(&mut self, ctid: [u16; 3]) -> bool;
+    fn filter_fetch(&mut self, ctid: [u16; 3]) -> Option<(&[Datum; 32], &[bool; 32])>;
+    fn filter_only(&self, ctid: [u16; 3]) -> bool;
 }
 
 impl<T: SearchFetcher, F: FnOnce() -> T> SearchFetcher for LazyCell<T, F> {
-    fn fetch(&mut self, key: [u16; 3]) -> Option<(&[Datum; 32], &[bool; 32])> {
-        LazyCell::force_mut(self).fetch(key)
+    fn filter_fetch(&mut self, key: [u16; 3]) -> Option<(&[Datum; 32], &[bool; 32])> {
+        LazyCell::force_mut(self).filter_fetch(key)
     }
-    fn filter(&mut self, key: [u16; 3]) -> bool {
-        LazyCell::force_mut(self).filter(key)
+    fn filter_only(&self, key: [u16; 3]) -> bool {
+        LazyCell::force(self).filter_only(key)
     }
 }

--- a/src/index/scanners/mod.rs
+++ b/src/index/scanners/mod.rs
@@ -46,10 +46,14 @@ pub trait SearchBuilder: 'static {
 
 pub trait SearchFetcher {
     fn fetch(&mut self, ctid: [u16; 3]) -> Option<(&[Datum; 32], &[bool; 32])>;
+    fn filter(&mut self, ctid: [u16; 3]) -> bool;
 }
 
 impl<T: SearchFetcher, F: FnOnce() -> T> SearchFetcher for LazyCell<T, F> {
     fn fetch(&mut self, key: [u16; 3]) -> Option<(&[Datum; 32], &[bool; 32])> {
         LazyCell::force_mut(self).fetch(key)
+    }
+    fn filter(&mut self, key: [u16; 3]) -> bool {
+        LazyCell::force_mut(self).filter(key)
     }
 }

--- a/tests/logic/rerank_in_table.slt
+++ b/tests/logic/rerank_in_table.slt
@@ -80,7 +80,7 @@ SELECT id FROM t_expr WHERE id <= 5 OR id % 2 = 1 ORDER BY ARRAY[id::real, id::r
 13
 
 statement ok
-SET vchordrq.prererank_filtering to off;
+SET vchordrq.prefilter to off;
 
 query I
 SELECT ARRAY(SELECT id FROM t_expr WHERE (id <= 5 OR id % 2 = 1) OR e >= 2000 ORDER BY ARRAY[id::real, id::real, id::real]::vector(3) <-> q LIMIT 9) FROM (VALUES ('[1.9,1.99,1.999]'::vector, 1999), ('[2.1,2.11,2.111]', 2111)) AS t(q, e);
@@ -89,7 +89,7 @@ SELECT ARRAY(SELECT id FROM t_expr WHERE (id <= 5 OR id % 2 = 1) OR e >= 2000 OR
 {2,3,1,4,5,6,7,8,9}
 
 statement ok
-SET vchordrq.prererank_filtering to on;
+SET vchordrq.prefilter to on;
 
 query I
 SELECT ARRAY(SELECT id FROM t_expr WHERE (id <= 5 OR id % 2 = 1) OR e >= 2000 ORDER BY ARRAY[id::real, id::real, id::real]::vector(3) <-> q LIMIT 9) FROM (VALUES ('[1.9,1.99,1.999]'::vector, 1999), ('[2.1,2.11,2.111]', 2111)) AS t(q, e);


### PR DESCRIPTION
## Feat
- Allow non-heap prefilter: enabled when `rerank_in_table=false(default)` and `SET vchordrq.prererank_filtering=on`
- Support streamio in heap prefilter and heap postfilter: enabled when `rerank_in_table=true` and `SET vchordrq.io_rerank = read_stream(default)`

## Optimization
- Eliminating computational costs at heap prefilter and heap postfilter(when `rerank_in_table=true`)