### PR TITLE
fix: build error on Apple Silicon due to ambiguous call to `svwhilelt` functions

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [env]
 CC = "clang"
+
+[target.'cfg(target_os="macos")']
+rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]

--- a/crates/simd/cshim/aarch64.c
+++ b/crates/simd/cshim/aarch64.c
@@ -84,7 +84,7 @@ fp16_reduce_sum_of_xy_a2_fp16(f16 *restrict a, f16 *restrict b, size_t n) {
 __attribute__((target("+sve"))) float
 fp16_reduce_sum_of_xy_a3_512(f16 *restrict a, f16 *restrict b, size_t n) {
   svfloat16_t xy = svdup_f16(0.0);
-  for (size_t i = 0; i < n; i += svcnth()) {
+  for (uint64_t i = 0; i < n; i += svcnth()) {
     svbool_t mask = svwhilelt_b16(i, n);
     svfloat16_t x = svld1_f16(mask, a + i);
     svfloat16_t y = svld1_f16(mask, b + i);
@@ -153,7 +153,7 @@ fp16_reduce_sum_of_d2_a2_fp16(f16 *restrict a, f16 *restrict b, size_t n) {
 __attribute__((target("+sve"))) float
 fp16_reduce_sum_of_d2_a3_512(f16 *restrict a, f16 *restrict b, size_t n) {
   svfloat16_t d2 = svdup_f16(0.0);
-  for (size_t i = 0; i < n; i += svcnth()) {
+  for (uint64_t i = 0; i < n; i += svcnth()) {
     svbool_t mask = svwhilelt_b16(i, n);
     svfloat16_t x = svld1_f16(mask, a + i);
     svfloat16_t y = svld1_f16(mask, b + i);
@@ -166,7 +166,7 @@ fp16_reduce_sum_of_d2_a3_512(f16 *restrict a, f16 *restrict b, size_t n) {
 __attribute__((target("+sve"))) float
 fp32_reduce_sum_of_x_a3_256(float *restrict this, size_t n) {
   svfloat32_t sum = svdup_f32(0.0);
-  for (size_t i = 0; i < n; i += svcntw()) {
+  for (uint64_t i = 0; i < n; i += svcntw()) {
     svbool_t mask = svwhilelt_b32(i, n);
     svfloat32_t x = svld1_f32(mask, this + i);
     sum = svadd_f32_x(mask, sum, x);
@@ -177,7 +177,7 @@ fp32_reduce_sum_of_x_a3_256(float *restrict this, size_t n) {
 __attribute__((target("+sve"))) float
 fp32_reduce_sum_of_abs_x_a3_256(float *restrict this, size_t n) {
   svfloat32_t sum = svdup_f32(0.0);
-  for (size_t i = 0; i < n; i += svcntw()) {
+  for (uint64_t i = 0; i < n; i += svcntw()) {
     svbool_t mask = svwhilelt_b32(i, n);
     svfloat32_t x = svld1_f32(mask, this + i);
     sum = svadd_f32_x(mask, sum, svabs_f32_x(mask, x));
@@ -188,7 +188,7 @@ fp32_reduce_sum_of_abs_x_a3_256(float *restrict this, size_t n) {
 __attribute__((target("+sve"))) float
 fp32_reduce_sum_of_x2_a3_256(float *restrict this, size_t n) {
   svfloat32_t sum = svdup_f32(0.0);
-  for (size_t i = 0; i < n; i += svcntw()) {
+  for (uint64_t i = 0; i < n; i += svcntw()) {
     svbool_t mask = svwhilelt_b32(i, n);
     svfloat32_t x = svld1_f32(mask, this + i);
     sum = svmla_f32_x(mask, sum, x, x);
@@ -201,7 +201,7 @@ fp32_reduce_min_max_of_x_a3_256(float *restrict this, size_t n, float *out_min,
                                 float *out_max) {
   svfloat32_t min = svdup_f32(1.0 / 0.0);
   svfloat32_t max = svdup_f32(-1.0 / 0.0);
-  for (size_t i = 0; i < n; i += svcntw()) {
+  for (uint64_t i = 0; i < n; i += svcntw()) {
     svbool_t mask = svwhilelt_b32(i, n);
     svfloat32_t x = svld1_f32(mask, this + i);
     min = svmin_f32_x(mask, min, x);
@@ -215,7 +215,7 @@ __attribute__((target("+sve"))) float
 fp32_reduce_sum_of_xy_a3_256(float *restrict lhs, float *restrict rhs,
                              size_t n) {
   svfloat32_t sum = svdup_f32(0.0);
-  for (size_t i = 0; i < n; i += svcntw()) {
+  for (uint64_t i = 0; i < n; i += svcntw()) {
     svbool_t mask = svwhilelt_b32(i, n);
     svfloat32_t x = svld1_f32(mask, lhs + i);
     svfloat32_t y = svld1_f32(mask, rhs + i);
@@ -228,7 +228,7 @@ __attribute__((target("+sve"))) float
 fp32_reduce_sum_of_d2_a3_256(float *restrict lhs, float *restrict rhs,
                              size_t n) {
   svfloat32_t sum = svdup_f32(0.0);
-  for (size_t i = 0; i < n; i += svcntw()) {
+  for (uint64_t i = 0; i < n; i += svcntw()) {
     svbool_t mask = svwhilelt_b32(i, n);
     svfloat32_t x = svld1_f32(mask, lhs + i);
     svfloat32_t y = svld1_f32(mask, rhs + i);


### PR DESCRIPTION
I'm using PostgreSQL 17 from Homebrew (`brew install postgresql@17`) and I ran the following steps to build VectorChord:

```sh
cargo install cargo-pgrx@"$(sed -n 's/.*pgrx = { version = "\(=.*\)",.*/\1/p' Cargo.toml)" --locked
cargo pgrx init --pg17=pg_config-17
cargo pgrx install --release --sudo --pg-config pg_config-17
```

However `cargo pgrx install` returns the following error:

```
[...]
warning: simd@0.0.0: ./cshim/aarch64.c:88:21: error: call to 'svwhilelt_b16' is ambiguous
warning: simd@0.0.0:    88 |     svbool_t mask = svwhilelt_b16(i, n);
warning: simd@0.0.0:       |                     ^~~~~~~~~~~~~
warning: simd@0.0.0: /Library/Developer/CommandLineTools/usr/lib/clang/16/include/arm_sve.h:28294:10: note: candidate function
warning: simd@0.0.0:  28294 | svbool_t svwhilelt_b16(uint32_t, uint32_t);
warning: simd@0.0.0:        |          ^
warning: simd@0.0.0: /Library/Developer/CommandLineTools/usr/lib/clang/16/include/arm_sve.h:28302:10: note: candidate function
warning: simd@0.0.0:  28302 | svbool_t svwhilelt_b16(uint64_t, uint64_t);
warning: simd@0.0.0:        |          ^
warning: simd@0.0.0: /Library/Developer/CommandLineTools/usr/lib/clang/16/include/arm_sve.h:28310:10: note: candidate function
warning: simd@0.0.0:  28310 | svbool_t svwhilelt_b16(int32_t, int32_t);
warning: simd@0.0.0:        |          ^
warning: simd@0.0.0: /Library/Developer/CommandLineTools/usr/lib/clang/16/include/arm_sve.h:28318:10: note: candidate function
warning: simd@0.0.0:  28318 | svbool_t svwhilelt_b16(int64_t, int64_t);
warning: simd@0.0.0:        |          ^
[...]
error: failed to run custom build command for `simd v0.0.0 (/private/var/folders/jj/g3vtj8y11hq32pvps93f7d7c0000gn/T/vectorchord.Fvs7ZJ4EKr/crates/simd)`
[...]
  error occurred in cc-rs: command did not execute successfully (status code exit status: 1): env -u IPHONEOS_DEPLOYMENT_TARGET LC_ALL="C" "clang" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-2" "-fno-omit-frame-pointer" "--target=arm64-apple-macosx" "-mmacosx-version-min=15.2" "-Wall" "-Wextra" "-o" "/private/var/folders/jj/g3vtj8y11hq32pvps93f7d7c0000gn/T/vectorchord.Fvs7ZJ4EKr/target/release/build/simd-eb45d325f597ce0a/out/bb6bfe1d2e603894-aarch64.o" "-c" "./cshim/aarch64.c"
```

This change fixes the error above and makes sure the correct function is picked by the compiler.