### PR TITLE
feat: query recall eval func

### DIFF
--- a/src/index/gucs.rs
+++ b/src/index/gucs.rs
@@ -36,6 +36,8 @@ pub enum PostgresIo {
     ReadStream,
 }
 
+static VCHORDG_ENABLE_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
+
 static VCHORDG_EF_SEARCH: GucSetting<i32> = GucSetting::<i32>::new(64);
 
 static VCHORDG_BEAM_SEARCH: GucSetting<i32> = GucSetting::<i32>::new(1);
@@ -55,6 +57,8 @@ static VCHORDG_IO_RERANK: GucSetting<PostgresIo> = GucSetting::<PostgresIo>::new
     #[cfg(any(feature = "pg17", feature = "pg18"))]
     PostgresIo::ReadStream,
 );
+
+static VCHORDRQ_ENABLE_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
 
 static VCHORDRQ_PROBES: GucSetting<Option<CString>> = GucSetting::<Option<CString>>::new(Some(c""));
 
@@ -83,6 +87,14 @@ static VCHORDRQ_IO_RERANK: GucSetting<PostgresIo> = GucSetting::<PostgresIo>::ne
 );
 
 pub fn init() {
+    GucRegistry::define_bool_guc(
+        c"vchordrq.enable_scan",
+        c"`enable_scan` argument of vchordrq.",
+        c"`enable_scan` argument of vchordrq.",
+        &VCHORDRQ_ENABLE_SCAN,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
     GucRegistry::define_string_guc(
         c"vchordrq.probes",
         c"`probes` argument of vchordrq.",
@@ -161,6 +173,14 @@ pub fn init() {
         #[cfg(any(feature = "pg15", feature = "pg16", feature = "pg17", feature = "pg18"))]
         pgrx::pg_sys::MarkGUCPrefixReserved(c"vchordrq".as_ptr());
     }
+    GucRegistry::define_bool_guc(
+        c"vchordg.enable_scan",
+        c"`enable_scan` argument of vchordg.",
+        c"`enable_scan` argument of vchordg.",
+        &VCHORDG_ENABLE_SCAN,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
     GucRegistry::define_int_guc(
         c"vchordg.ef_search",
         c"`ef_search` argument of vchordg.",
@@ -215,6 +235,10 @@ pub fn init() {
     }
 }
 
+pub fn vchordg_enable_scan() -> bool {
+    VCHORDG_ENABLE_SCAN.get()
+}
+
 pub fn vchordg_ef_search() -> u32 {
     VCHORDG_EF_SEARCH.get() as u32
 }
@@ -246,6 +270,10 @@ pub fn vchordg_io_rerank() -> crate::index::vchordg::scanners::Io {
         #[cfg(any(feature = "pg17", feature = "pg18"))]
         PostgresIo::ReadStream => Io::Stream,
     }
+}
+
+pub fn vchordrq_enable_scan() -> bool {
+    VCHORDRQ_ENABLE_SCAN.get()
 }
 
 pub fn vchordrq_probes() -> Vec<u32> {

--- a/src/index/vchordg/am/mod.rs
+++ b/src/index/vchordg/am/mod.rs
@@ -160,6 +160,15 @@ pub unsafe extern "C-unwind" fn amcostestimate(
     index_pages: *mut f64,
 ) {
     unsafe {
+        use pgrx::pg_sys::disable_cost;
+        if !gucs::vchordg_enable_scan() {
+            *index_startup_cost = disable_cost;
+            *index_total_cost = disable_cost;
+            *index_selectivity = 0.0;
+            *index_correlation = 0.0;
+            *index_pages = 1.0;
+            return;
+        }
         *index_startup_cost = 0.0;
         *index_total_cost = 0.0;
         *index_selectivity = 1.0;

--- a/src/index/vchordrq/am/mod.rs
+++ b/src/index/vchordrq/am/mod.rs
@@ -163,7 +163,9 @@ pub unsafe extern "C-unwind" fn amcostestimate(
         use pgrx::pg_sys::disable_cost;
         let index_opt_info = (*path).indexinfo;
         // do not use index, if there are no orderbys or clauses
-        if (*path).indexorderbys.is_null() && (*path).indexclauses.is_null() {
+        if ((*path).indexorderbys.is_null() && (*path).indexclauses.is_null())
+            || !gucs::vchordrq_enable_scan()
+        {
             *index_startup_cost = disable_cost;
             *index_total_cost = disable_cost;
             *index_selectivity = 0.0;

--- a/src/sql/finalize.sql
+++ b/src/sql/finalize.sql
@@ -148,6 +148,75 @@ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', '_vchordrq_amhan
 CREATE FUNCTION vchordrq_prewarm(regclass, integer default 0) RETURNS TEXT
 STRICT LANGUAGE c AS 'MODULE_PATHNAME', '_vchordrq_prewarm_wrapper';
 
+CREATE FUNCTION vchordrq_evaluate_query_recall(
+    query text,
+    exact_search boolean default false,
+    accu_epsilon real default 1.9
+)
+RETURNS real
+LANGUAGE plpgsql
+STRICT
+AS $$
+DECLARE
+    rough tid[];
+    accu tid[];
+    match_count integer := 0;
+    accu_k integer;
+    recall real;
+    rough_probes text;
+    accu_probes text;
+BEGIN
+    IF query LIKE '%@#%' AND NOT exact_search THEN
+        RAISE EXCEPTION 'MaxSim operator cannot be used for estimated recall evaluation. Please use exact_search => true.';
+    END IF;
+    IF NOT exact_search THEN
+        BEGIN
+            rough_probes := current_setting('vchordrq.probes');
+        END;
+    END IF;
+
+    BEGIN
+        EXECUTE
+            format('SELECT coalesce(array_agg(id), array[]::tid[]) FROM (%s) AS result(id)', query)
+        INTO
+            rough;
+    EXCEPTION WHEN OTHERS THEN
+        RAISE EXCEPTION 'Error executing ANN query "%": %', query, SQLERRM;
+    END;
+
+    BEGIN
+        IF exact_search THEN
+            SET LOCAL vchordrq.enable_scan = off;
+        ELSE
+            IF rough_probes = '' THEN
+                accu_probes := '';
+            ELSIF position(',' in rough_probes) > 0 THEN
+                accu_probes := '65535,65535';
+            ELSE
+                accu_probes := '65535';
+            END IF;
+            EXECUTE format('SET LOCAL "vchordrq.probes" = %L', accu_probes);
+            EXECUTE format('SET LOCAL "vchordrq.epsilon" = %L', accu_epsilon);
+            SET LOCAL vchordrq.max_scan_tuples = -1;
+        END IF;
+        EXECUTE
+            format('SELECT coalesce(array_agg(id), array[]::tid[]) FROM (%s) AS result(id)', query)
+        INTO
+            accu;
+    EXCEPTION WHEN OTHERS THEN
+         RAISE EXCEPTION 'Error executing Ground Truth query "%": %', query, SQLERRM;
+    END;
+    accu_k := cardinality(accu);
+    IF accu_k = 0 THEN
+        RAISE WARNING  'Query "%": No results found, returning NaN for recall.', query;
+        RETURN 'NaN';
+    END IF;
+    SELECT COUNT(*) INTO match_count FROM (SELECT unnest(rough) INTERSECT SELECT unnest(accu)) AS tids;
+    recall := match_count::real / accu_k::real;
+    RETURN recall;
+END;
+$$;
+
 CREATE FUNCTION vchordg_amhandler(internal) RETURNS index_am_handler
 IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', '_vchordg_amhandler_wrapper';
 

--- a/tests/vchordrq/recall.slt
+++ b/tests/vchordrq/recall.slt
@@ -1,0 +1,53 @@
+statement ok
+CREATE TABLE t (val vector(3));
+
+statement ok
+INSERT INTO t (val)
+SELECT ARRAY[i * 0.0001, i * 0.00005, i * 0.0002]::vector(3) FROM generate_series(1, 10000) as s(i);
+
+statement ok
+CREATE INDEX ON t USING vchordrq (val vector_l2_ops);
+
+statement ok
+SET vchordrq.epsilon = 0.8;
+
+statement ok
+SET vchordrq.probes = '1';
+
+statement error MaxSim operator cannot be used for estimated recall
+SELECT * from vchordrq_evaluate_query_recall(query=>'@#');
+
+statement error Error executing ANN query
+SELECT * from vchordrq_evaluate_query_recall(query=>$$SELECT ctid FROM t ORDER BY val <-> '[0.5, 0.25, 1.0]' LIMIT 10$$);
+
+statement ok
+SET vchordrq.probes = '';
+
+statement error Error executing ANN query
+SELECT * from vchordrq_evaluate_query_recall(query=>$$SELECT val FROM t ORDER BY val <-> '[0.5, 0.25, 1.0]' LIMIT 10$$);
+
+statement error Error executing ANN query
+SELECT * from vchordrq_evaluate_query_recall(query=>$$SELECT * FROM t ORDER BY val <-> '[0.5, 0.25, 1.0]' LIMIT 10$$);
+
+query I
+SELECT * from vchordrq_evaluate_query_recall(query=>$$SELECT ctid FROM t ORDER BY val <-> '[0.5, 0.25, 1.0]' LIMIT 10$$);
+----
+1
+
+query I
+SELECT * from vchordrq_evaluate_query_recall(query=>$$SELECT ctid FROM t ORDER BY val <-> '[0.5, 0.25, 1.0]' LIMIT 10$$, exact_search=>true);
+----
+1
+
+query I
+SELECT * from vchordrq_evaluate_query_recall(query=>$$SELECT ctid FROM t WHERE FALSE ORDER BY val <-> '[0.5, 0.25, 1.0]' LIMIT 10$$);
+----
+NaN
+
+query I
+SHOW vchordrq.epsilon;
+----
+0.8
+
+statement ok
+DROP TABLE t;


### PR DESCRIPTION
## Usages

```sql
> SELECT vchordrq_evaluate_query_recall(query_text =>$$SELECT ctid FROM test ORDER BY val <-> '[0.5, 0.25, 1.0]' LIMIT 10$$);
 vchordrq_evaluate_query_recall 
--------------------------------
                              1
(1 row)

> SELECT vchordrq_evaluate_query_recall(query_text => $$SELECT ctid FROM test ORDER BY val <-> '[0.5, 0.25, 1.0]' LIMIT 100$$, exact_search=>true);
 vchordrq_evaluate_query_recall 
--------------------------------
                              1

> SELECT vchordrq_evaluate_query_recall(query_text => $$SELECT ctid FROM test WHERE FALSE' LIMIT 100$$, exact_search=>true);
 vchordrq_evaluate_query_recall 
--------------------------------
                              NaN
(1 row)
```