### PR TITLE
feat: record queries in internal table

### DIFF
--- a/src/index/capture.rs
+++ b/src/index/capture.rs
@@ -1,0 +1,361 @@
+// This software is licensed under a dual license model:
+//
+// GNU Affero General Public License v3 (AGPLv3): You may use, modify, and
+// distribute this software under the terms of the AGPLv3.
+//
+// Elastic License v2 (ELv2): You may also use, modify, and distribute this
+// software under the Elastic License v2, which has specific restrictions.
+//
+// We welcome any commercial collaboration or support. For inquiries
+// regarding the licenses, please contact us at:
+// vectorchord-inquiry@tensorchord.ai
+//
+// Copyright (c) 2025 TensorChord Inc.
+
+use crate::index::gucs;
+use crate::index::vchordrq::opclass::Opfamily;
+use pgrx::IntoDatum;
+use pgrx::pg_sys::Oid;
+use pgrx::pg_sys::panic::ErrorReportable;
+use pgrx_catalog::{PgClass, PgIndex, PgNamespace};
+use std::ffi::CString;
+use std::fmt;
+use std::sync::{LazyLock, RwLock};
+use vchordrq::types::OwnedVector;
+
+const INTERNAL_TABLE_NAME: &str = "_internal_vchord_query_storage";
+static INTERNAL_TABLE_SCHEMA: LazyLock<RwLock<String>> =
+    LazyLock::new(|| RwLock::new(String::from("public")));
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Operator {
+    L2,
+    Cosine,
+    Dot,
+}
+
+impl TryFrom<&str> for Operator {
+    type Error = &'static str;
+
+    fn try_from(text: &str) -> Result<Self, Self::Error> {
+        match text {
+            "<->" => Ok(Operator::L2),
+            "<=>" => Ok(Operator::Cosine),
+            "<#>" => Ok(Operator::Dot),
+            _ => Err("Unknown operator text"),
+        }
+    }
+}
+
+impl fmt::Display for Operator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Operator::L2 => write!(f, "<->"),
+            Operator::Cosine => write!(f, "<=>"),
+            Operator::Dot => write!(f, "<#>"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Query {
+    pub table_oid: u32,
+    pub index_oid: u32,
+    pub operator: Operator,
+    pub vector: Vec<f32>,
+}
+
+#[derive(Debug, Clone)]
+pub struct QueryDump {
+    pub namespace: String,
+    pub table_name: String,
+    pub column_name: String,
+    pub operator: String,
+    pub vector_text: String,
+    pub simplified_query: String,
+}
+
+impl Query {
+    pub fn new(
+        table_oid: u32,
+        index_oid: u32,
+        opfamily: Opfamily,
+        vector: OwnedVector,
+    ) -> Option<Self> {
+        let operator = match opfamily {
+            Opfamily::HalfvecCosine | Opfamily::VectorCosine => Operator::Cosine,
+            Opfamily::HalfvecIp | Opfamily::VectorIp => Operator::Dot,
+            Opfamily::HalfvecL2 | Opfamily::VectorL2 => Operator::L2,
+            Opfamily::VectorMaxsim | Opfamily::HalfvecMaxsim => return None,
+        };
+        let vector = match vector {
+            OwnedVector::Vecf32(v) => v.into_vec(),
+            OwnedVector::Vecf16(v) => v.into_vec().into_iter().map(|f| f.to_f32()).collect(),
+        };
+        Some(Self {
+            table_oid,
+            index_oid,
+            operator,
+            vector,
+        })
+    }
+
+    pub fn dump(&self) -> Option<QueryDump> {
+        let (table_name, namespace_oid) = {
+            let tuple = PgClass::search_reloid(self.table_oid.into());
+            if let Some(tuple) = tuple {
+                let pg_class = tuple.get().unwrap();
+                let name = pg_class.relname().to_str().map(|s| s.to_owned()).unwrap();
+                let namespace_oid_datum = pg_class.relnamespace();
+                (name, namespace_oid_datum)
+            } else {
+                pgrx::warning!(
+                    "Attribute with relid {} not found in syscache",
+                    self.table_oid,
+                );
+                return None;
+            }
+        };
+        let namespace = {
+            let tuple = PgNamespace::search_namespaceoid(namespace_oid);
+            if let Some(tuple) = tuple {
+                let pg_class = tuple.get().unwrap();
+                pg_class.nspname().to_str().map(|s| s.to_owned()).unwrap()
+            } else {
+                pgrx::warning!("Namespace with oid {} not found in syscache", namespace_oid,);
+                return None;
+            }
+        };
+        let column_attnum = {
+            let tuple = PgIndex::search_indexrelid(self.index_oid.into());
+            if let Some(tuple) = tuple {
+                let pg_index = tuple.get().unwrap();
+                *pg_index
+                    .indkey()
+                    .first()
+                    .expect("Index should have at least one column")
+            } else {
+                pgrx::warning!("Index with oid {} not found in syscache", self.index_oid,);
+                return None;
+            }
+        };
+        let column_name = unsafe {
+            let table_oid_datum = Oid::from_u32(self.table_oid).into_datum().unwrap();
+            let column_attnum_datum = column_attnum.into_datum().unwrap();
+            let tuple = pgrx::pg_sys::SearchSysCache2(
+                pgrx::pg_sys::SysCacheIdentifier::ATTNUM as i32,
+                table_oid_datum,
+                column_attnum_datum,
+            );
+            if tuple.is_null() {
+                pgrx::warning!(
+                    "Attribute with relid {} and attno {} not found in syscache",
+                    self.table_oid,
+                    column_attnum
+                );
+                return None;
+            }
+            #[cfg(not(any(feature = "pg13", feature = "pg14", feature = "pg15")))]
+            let inner = {
+                let mut is_null = false;
+                let datum = pgrx::pg_sys::SysCacheGetAttr(
+                    pgrx::pg_sys::SysCacheIdentifier::ATTNUM as i32,
+                    tuple,
+                    pgrx::pg_sys::Anum_pg_attribute_attname as i16,
+                    &mut is_null,
+                );
+                pgrx::pg_sys::DatumGetName(datum).as_ref().unwrap()
+            };
+            #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15"))]
+            let inner = &(*pgrx::pg_sys::GETSTRUCT(tuple)
+                .cast::<pgrx::pg_sys::FormData_pg_attribute>())
+            .attname;
+
+            let result = pgrx::pg_sys::name_data_to_str(inner).to_string();
+            pgrx::pg_sys::ReleaseSysCache(tuple);
+            result
+        };
+        let operator = self.operator.to_string();
+        let vector_format: Vec<String> = self.vector.iter().map(|f| format!("{f:.2}")).collect();
+        let joined_elements = vector_format.join(", ");
+        let vector_text = format!("'[{joined_elements}]'");
+        let simplified_query = format!(
+            "SELECT ctid from {namespace}.{table_name} ORDER BY {column_name} {operator} {vector_text}"
+        );
+        Some(QueryDump {
+            namespace,
+            table_name,
+            column_name,
+            operator,
+            vector_text,
+            simplified_query,
+        })
+    }
+}
+
+pub struct QueryLoggerMaster {}
+
+impl QueryLoggerMaster {
+    pub fn init() {
+        pgrx::spi::Spi::connect_mut(|client| {
+            let namespace_query = "SELECT n.nspname::TEXT
+                FROM pg_catalog.pg_extension e
+                LEFT JOIN pg_catalog.pg_namespace n ON n.oid = e.extnamespace
+                WHERE e.extname = 'vchord';";
+            let vchord_namespace: String = client
+                .select(namespace_query, None, &[])
+                .unwrap_or_report()
+                .first()
+                .get_by_name("nspname")
+                .expect("external build: cannot get namespace of vchord")
+                .expect("external build: cannot get namespace of vchord");
+            let mut namespace_guard = INTERNAL_TABLE_SCHEMA.write().unwrap();
+            *namespace_guard = vchord_namespace.clone();
+
+            let namespace_oid = {
+                let c_namespace = CString::new(vchord_namespace.as_str()).unwrap();
+                let tuple = PgNamespace::search_namespacename(&c_namespace);
+                if let Some(tuple) = tuple {
+                    let pg_namespace = tuple.get().unwrap();
+                    pg_namespace.oid()
+                } else {
+                    pgrx::warning!(
+                        "Namespace with namespace {:?} not found in syscache",
+                        c_namespace
+                    );
+                    return;
+                }
+            };
+            let exist = {
+                let c_table = CString::new(INTERNAL_TABLE_NAME).unwrap();
+                let tuple = PgClass::search_relnamensp(&c_table, namespace_oid);
+                if let Some(inner) = tuple
+                    && inner.get().is_some()
+                {
+                    true
+                } else {
+                    false
+                }
+            };
+
+            if !exist {
+                let create_sql = format!(
+                    "CREATE TABLE IF NOT EXISTS {vchord_namespace}.{INTERNAL_TABLE_NAME} (
+                     id BIGSERIAL PRIMARY KEY, table_oid OID, index_oid OID,
+                     operator TEXT, data TEXT)",
+                );
+                let _ = client.update(&create_sql, None, &[]);
+            }
+        });
+    }
+
+    pub fn push(query: Query) {
+        let namespace_guard = INTERNAL_TABLE_SCHEMA.read().unwrap();
+        let namespace = &*namespace_guard;
+        let Query {
+            table_oid,
+            index_oid,
+            operator,
+            vector,
+        } = query;
+        let ops = operator.to_string();
+        let vector_format: Vec<String> = vector.iter().map(|f| format!("{f:.2}")).collect();
+        let joined_elements = vector_format.join(", ");
+        let vector_text_rep = format!("[{joined_elements}]");
+        pgrx::spi::Spi::connect_mut(|client| {
+            let insert_sql = format!(
+                "INSERT INTO {namespace}.{INTERNAL_TABLE_NAME} (table_oid, index_oid, operator, data) VALUES
+                     ({table_oid}, {index_oid}, '{ops}', '{vector_text_rep}')",
+            );
+            let _ = client.update(&insert_sql, None, &[]);
+        });
+    }
+
+    pub fn maintain() {
+        Self::init();
+        let namespace_guard = INTERNAL_TABLE_SCHEMA.read().unwrap();
+        let namespace = &*namespace_guard;
+        let limit = gucs::vchordrq_log_queries_size();
+        pgrx::spi::Spi::connect_mut(|client| {
+            let delete_sql = format!(
+                "DELETE FROM {namespace}.{INTERNAL_TABLE_NAME} WHERE id NOT IN (
+                    SELECT id FROM {namespace}.{INTERNAL_TABLE_NAME} ORDER BY id DESC LIMIT {limit})"
+            );
+            let _ = client.update(&delete_sql, None, &[]);
+        });
+    }
+
+    pub fn load_all() -> Vec<Query> {
+        let limit = gucs::vchordrq_log_queries_size();
+        let mut queries = Vec::new();
+        let namespace_guard = INTERNAL_TABLE_SCHEMA.read().unwrap();
+        let namespace = &*namespace_guard;
+
+        let query_sql = format!(
+            "SELECT table_oid, index_oid, operator, data
+             FROM {namespace}.{INTERNAL_TABLE_NAME} ORDER BY id DESC LIMIT {limit}",
+        );
+
+        pgrx::spi::Spi::connect(|client| {
+            let rows = client
+                .select(&query_sql, Some(limit as i64), &[])
+                .unwrap_or_report();
+            'r: for row in rows {
+                let table_oid: Oid = if let Some(e) = row.get_by_name("table_oid").unwrap() {
+                    e
+                } else {
+                    pgrx::warning!("table_oid is null in logged query");
+                    continue 'r;
+                };
+                let index_oid: Oid = if let Some(e) = row.get_by_name("index_oid").unwrap() {
+                    e
+                } else {
+                    pgrx::warning!("index_oid is null in logged query");
+                    continue 'r;
+                };
+                let operator: &str = if let Some(e) = row.get_by_name("operator").unwrap() {
+                    e
+                } else {
+                    pgrx::warning!("operator is null in logged query");
+                    continue 'r;
+                };
+                let vector_text: &str = if let Some(e) = row.get_by_name("data").unwrap() {
+                    e
+                } else {
+                    continue 'r;
+                };
+                let vector_text = vector_text.trim();
+                let inner_str = &vector_text[1..vector_text.len() - 1];
+                if inner_str.trim().is_empty() {
+                    pgrx::warning!("Empty vector text, skipping");
+                    continue 'r;
+                }
+                let parts = inner_str.split(',');
+
+                let mut vector = Vec::new();
+                for part in parts {
+                    let trimmed_part = part.trim();
+                    if trimmed_part.is_empty() {
+                        pgrx::warning!("Empty part in vector text, skipping");
+                        continue 'r;
+                    }
+                    match trimmed_part.parse::<f32>() {
+                        Ok(value) => vector.push(value),
+                        Err(e) => {
+                            pgrx::warning!("Failed to parse vector part '{}': {}", trimmed_part, e);
+                            continue 'r;
+                        }
+                    }
+                }
+
+                queries.push(Query {
+                    table_oid: table_oid.into(),
+                    index_oid: index_oid.into(),
+                    operator: Operator::try_from(operator).expect("Failed to parse operator"),
+                    vector,
+                });
+            }
+            queries
+        })
+    }
+}

--- a/src/index/gucs.rs
+++ b/src/index/gucs.rs
@@ -36,6 +36,9 @@ pub enum PostgresIo {
     ReadStream,
 }
 
+static VCHORDRQ_LOG_QUERIES_SIZE: GucSetting<i32> = GucSetting::<i32>::new(0);
+static VCHORDRQ_LOG_QUERIES_SAMPLE_RATE: GucSetting<i32> = GucSetting::<i32>::new(100);
+
 static VCHORDG_ENABLE_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
 
 static VCHORDG_EF_SEARCH: GucSetting<i32> = GucSetting::<i32>::new(64);
@@ -164,6 +167,26 @@ pub fn init() {
         c"`io_rerank` argument of vchordrq.",
         c"`io_rerank` argument of vchordrq.",
         &VCHORDRQ_IO_RERANK,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+    GucRegistry::define_int_guc(
+        c"vchordrq.log_queries_size",
+        c"`log_queries_size` argument of vchordrq.",
+        c"`log_queries_size` argument of vchordrq.",
+        &VCHORDRQ_LOG_QUERIES_SIZE,
+        0,
+        10000,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+    GucRegistry::define_int_guc(
+        c"vchordrq.log_queries_sample_rate",
+        c"`log_queries_sample_rate` argument of vchordrq.",
+        c"`log_queries_sample_rate` argument of vchordrq.",
+        &VCHORDRQ_LOG_QUERIES_SAMPLE_RATE,
+        1,
+        10000,
         GucContext::Userset,
         GucFlags::default(),
     );
@@ -343,4 +366,12 @@ pub fn vchordrq_io_rerank() -> crate::index::vchordrq::scanners::Io {
         #[cfg(any(feature = "pg17", feature = "pg18"))]
         PostgresIo::ReadStream => Io::Stream,
     }
+}
+
+pub fn vchordrq_log_queries_size() -> u32 {
+    VCHORDRQ_LOG_QUERIES_SIZE.get() as u32
+}
+
+pub fn vchordrq_log_queries_sample_rate() -> u32 {
+    VCHORDRQ_LOG_QUERIES_SAMPLE_RATE.get() as u32
 }

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -12,6 +12,7 @@
 //
 // Copyright (c) 2025 TensorChord Inc.
 
+pub mod capture;
 pub mod fetcher;
 pub mod functions;
 pub mod gucs;

--- a/src/index/vchordg/am/mod.rs
+++ b/src/index/vchordg/am/mod.rs
@@ -296,6 +296,7 @@ pub unsafe extern "C-unwind" fn amvacuumcleanup(
         pgrx::pg_sys::vacuum_delay_point(false);
     };
     crate::index::vchordg::algo::maintain(opfamily, &index, check);
+    crate::index::capture::QueryLoggerMaster::maintain();
     stats
 }
 

--- a/src/index/vchordrq/am/am_build.rs
+++ b/src/index/vchordrq/am/am_build.rs
@@ -255,6 +255,7 @@ pub unsafe extern "C-unwind" fn ambuild(
     index_info: *mut pgrx::pg_sys::IndexInfo,
 ) -> *mut pgrx::pg_sys::IndexBuildResult {
     use validator::Validate;
+    crate::index::capture::QueryLoggerMaster::init();
     let (vector_options, vchordrq_options) = unsafe { options(index_relation) };
     if let Err(errors) = Validate::validate(&vector_options) {
         pgrx::error!("error while validating options: {}", errors);

--- a/src/index/vchordrq/am/mod.rs
+++ b/src/index/vchordrq/am/mod.rs
@@ -376,6 +376,7 @@ pub unsafe extern "C-unwind" fn amvacuumcleanup(
         pgrx::pg_sys::vacuum_delay_point(false);
     };
     crate::index::vchordrq::algo::maintain(opfamily, &index, check);
+    crate::index::capture::QueryLoggerMaster::maintain();
     stats
 }
 
@@ -460,6 +461,8 @@ pub unsafe extern "C-unwind" fn amrescan(
             | Opfamily::HalfvecIp
             | Opfamily::HalfvecCosine => {
                 let mut builder = DefaultBuilder::new(opfamily);
+                builder.set_table_oid((*(*scan).heapRelation).rd_id.to_u32());
+                builder.set_index_oid((*(*scan).indexRelation).rd_id.to_u32());
                 for i in 0..(*scan).numberOfOrderBys {
                     let data = (*scan).orderByData.add(i as usize);
                     let value = (*data).sk_argument;

--- a/src/sql/bootstrap.sql
+++ b/src/sql/bootstrap.sql
@@ -4,3 +4,12 @@ CREATE TYPE scalar8;
 CREATE TYPE sphere_vector;
 CREATE TYPE sphere_halfvec;
 CREATE TYPE sphere_scalar8;
+
+CREATE TYPE logged_query AS (
+    table_schema TEXT,
+    table_name TEXT,
+    column_name TEXT,
+    operator TEXT,
+    vector_text TEXT,
+    simplified_query TEXT
+);

--- a/src/sql/finalize.sql
+++ b/src/sql/finalize.sql
@@ -142,6 +142,9 @@ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', '_vchord_vector_
 CREATE FUNCTION quantize_to_scalar8(halfvec) RETURNS scalar8
 IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', '_vchord_halfvec_quantize_to_scalar8_wrapper';
 
+CREATE FUNCTION vchordrq_logged_queries() RETURNS SETOF logged_query
+STRICT LANGUAGE c AS 'MODULE_PATHNAME', '_vchordrq_logged_queries_wrapper';
+
 CREATE FUNCTION vchordrq_amhandler(internal) RETURNS index_am_handler
 IMMUTABLE STRICT PARALLEL SAFE LANGUAGE c AS 'MODULE_PATHNAME', '_vchordrq_amhandler_wrapper';
 
@@ -151,6 +154,7 @@ STRICT LANGUAGE c AS 'MODULE_PATHNAME', '_vchordrq_prewarm_wrapper';
 CREATE FUNCTION vchordrq_evaluate_query_recall(
     query text,
     exact_search boolean default false,
+    accu_probes TEXT default '',
     accu_epsilon real default 1.9
 )
 RETURNS real
@@ -164,7 +168,6 @@ DECLARE
     accu_k integer;
     recall real;
     rough_probes text;
-    accu_probes text;
 BEGIN
     IF query LIKE '%@#%' AND NOT exact_search THEN
         RAISE EXCEPTION 'MaxSim operator cannot be used for estimated recall evaluation. Please use exact_search => true.';
@@ -188,12 +191,14 @@ BEGIN
         IF exact_search THEN
             SET LOCAL vchordrq.enable_scan = off;
         ELSE
-            IF rough_probes = '' THEN
-                accu_probes := '';
-            ELSIF position(',' in rough_probes) > 0 THEN
-                accu_probes := '65535,65535';
-            ELSE
-                accu_probes := '65535';
+            IF accu_probes = '' THEN
+                IF rough_probes = '' THEN
+                    accu_probes := '';
+                ELSIF position(',' in rough_probes) > 0 THEN
+                    accu_probes := '65535,65535';
+                ELSE
+                    accu_probes := '65535';
+                END IF;
             END IF;
             EXECUTE format('SET LOCAL "vchordrq.probes" = %L', accu_probes);
             EXECUTE format('SET LOCAL "vchordrq.epsilon" = %L', accu_epsilon);

--- a/tests/vchordrq/recall.slt
+++ b/tests/vchordrq/recall.slt
@@ -1,5 +1,5 @@
 statement ok
-CREATE TABLE t (val vector(3));
+CREATE TABLE t (id SERIAL PRIMARY KEY, val vector(3));
 
 statement ok
 INSERT INTO t (val)
@@ -23,11 +23,14 @@ SELECT * from vchordrq_evaluate_query_recall(query=>$$SELECT ctid FROM t ORDER B
 statement ok
 SET vchordrq.probes = '';
 
-statement error Error executing ANN query
+statement error Error executing ANN query (.+) could not convert type
 SELECT * from vchordrq_evaluate_query_recall(query=>$$SELECT val FROM t ORDER BY val <-> '[0.5, 0.25, 1.0]' LIMIT 10$$);
 
-statement error Error executing ANN query
+statement error Error executing ANN query (.+) could not convert type
 SELECT * from vchordrq_evaluate_query_recall(query=>$$SELECT * FROM t ORDER BY val <-> '[0.5, 0.25, 1.0]' LIMIT 10$$);
+
+statement error Error executing Ground Truth query (.+) need 0 probes, but 1 probes provided
+SELECT * from vchordrq_evaluate_query_recall(query=>$$SELECT ctid FROM t ORDER BY val <-> '[0.5, 0.25, 1.0]' LIMIT 10$$, accu_probes=>'1');
 
 query I
 SELECT * from vchordrq_evaluate_query_recall(query=>$$SELECT ctid FROM t ORDER BY val <-> '[0.5, 0.25, 1.0]' LIMIT 10$$);
@@ -50,4 +53,58 @@ SHOW vchordrq.epsilon;
 0.8
 
 statement ok
-DROP TABLE t;
+CREATE TABLE t_dim4 (val vector(4), id SERIAL PRIMARY KEY);
+
+statement ok
+INSERT INTO t_dim4 (val)
+SELECT ARRAY[i * 0.0001, i * 0.00005, i * 0.0002, i * 0.001]::vector(4) FROM generate_series(1, 10000) as s(i);
+
+statement ok
+CREATE INDEX ON t_dim4 USING vchordrq (val vector_l2_ops);
+
+statement ok
+SET vchordrq.log_queries_size = 2;
+
+statement ok
+SET vchordrq.log_queries_sample_rate = 1;
+
+statement ok
+SELECT * from t ORDER BY val <-> '[0.50, 0.25, 1.00]';
+
+statement ok
+SELECT * from t_dim4 ORDER BY val <-> '[1.00, 0.50, 0.25, 0]';
+
+query I
+SELECT simplified_query from vchordrq_logged_queries();
+----
+SELECT ctid from public.t_dim4 ORDER BY val <-> '[1.00, 0.50, 0.25, 0.00]'
+SELECT ctid from public.t ORDER BY val <-> '[0.50, 0.25, 1.00]'
+
+statement ok
+SELECT * from t_dim4 ORDER BY val <-> '[2.00, 1, 0.5, 0]';
+
+statement ok
+VACUUM
+
+query I
+SELECT COUNT(*) from _internal_vchord_query_storage;
+----
+2
+
+query I
+SELECT simplified_query from vchordrq_logged_queries();
+----
+SELECT ctid from public.t_dim4 ORDER BY val <-> '[2.00, 1.00, 0.50, 0.00]'
+SELECT ctid from public.t_dim4 ORDER BY val <-> '[1.00, 0.50, 0.25, 0.00]'
+
+query I
+SELECT AVG(recall_value)
+FROM vchordrq_logged_queries() AS lq,
+LATERAL (
+    SELECT vchordrq_evaluate_query_recall(query=>lq.simplified_query) AS recall_value
+) AS eval_results;
+----
+1
+
+statement ok
+DROP TABLE t, t_dim4;


### PR DESCRIPTION
## GUC
* `vchordrq.log_queries_size`: Maximum logged queries number
  * 0 to 10000, default 0 (for disable record)
* `vchordrq.log_queries_sample_rate`: Rate of query to be logged
  * 1 to 10000, default 100 (for 1% rate)

## Table
* `_internal_vchord_query_storage`: Internal table to store queries
  * `table_oid`: Oid -> `table_schema` / `table_name`
  * `index_oid`: Oid -> `column_name`
  * `operator`: TEXT
  * `vector_text`: TEXT (Easy to INSERT through SPI SQL)

## Function
* `vchordrq_logged_queries`: Get logged queries

## Example
```sql
-- Preset
CREATE TABLE t (id SERIAL PRIMARY KEY, val vector(3));
INSERT INTO t (val)
SELECT ARRAY[i * 0.0001, i * 0.00005, i * 0.0002]::vector(3) FROM generate_series(1, 10000) as s(i);
CREATE INDEX ON t USING vchordrq (val vector_l2_ops);
CREATE TABLE t1 (val vector(4), id SERIAL PRIMARY KEY);
INSERT INTO t1 (val)
SELECT ARRAY[i * 0.0001, i * 0.00005, i * 0.0002, i * 0.001]::vector(4) FROM generate_series(1, 10000) as s(i);
CREATE INDEX ON t1 USING vchordrq (val vector_l2_ops);

-- Log up to 2 queries
SET vchordrq.log_queries_size = 2;
-- Record query at 1/1=100% rate
SET vchordrq.log_queries_sample_rate = 1;

-- Record
SELECT * from t ORDER BY val <-> '[0.50, 0.25, 1.00]';
SELECT val from t1 ORDER BY val <-> '[0.50, 0.25, 1.00, 0]';

SELECT * from vchordrq_logged_queries();

-- Result
 table_schema | table_name | column_name | operator |        vector_text         |                            simplified_query                            
--------------+------------+-------------+----------+----------------------------+------------------------------------------------------------------------
 public       | t1         | val         | <->      | '[0.50, 0.25, 1.00, 0.00]' | SELECT ctid from public.t1 ORDER BY val <-> '[0.50, 0.25, 1.00, 0.00]'
 public       | t          | val         | <->      | '[0.50, 0.25, 1.00]'       | SELECT ctid from public.t ORDER BY val <-> '[0.50, 0.25, 1.00]'

-- Recall metric
SELECT AVG(recall_value)
FROM vchordrq_logged_queries() AS lq,
LATERAL (
    SELECT vchordrq_evaluate_query_recall(query=>lq.simplified_query) AS recall_value
) AS eval_results;

-- Result
 avg 
-----
   1
```

## Maintain
* The internal table `_internal_vchord_query_storage` is:
  * Created (if not exist) when any `vchordrq` index is created
  * Trucated to `vchordrq.log_queries_size` when `VACCUM`

## Fix

Now user can assign customed `accu_probes` to the function `vchordrq_evaluate_query_recall`.

```sql
CREATE FUNCTION vchordrq_evaluate_query_recall(
    query text,
    exact_search boolean default false,
    accu_probes TEXT default '',
    accu_epsilon real default 1.9
)
```