### PR TITLE
fix: disable debuginfo on profile release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -91,7 +91,7 @@ checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -161,19 +161,19 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cargo_toml"
-version = "0.22.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02260d489095346e5cafd04dea8e8cb54d1d74fcd759022a9b72986ebe9a1257"
+checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
- "toml 0.8.23",
+ "toml 0.9.2",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "shlex",
 ]
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -226,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -416,7 +416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -545,7 +545,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -685,7 +685,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1110,9 +1110,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1203,15 +1203,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1285,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -1806,7 +1806,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1822,6 +1822,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -1954,9 +1963,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,11 +61,11 @@ edition = "2024"
 [workspace.dependencies]
 bumpalo = "3.19.0"
 half = { version = "2.6.0", features = ["zerocopy"] }
-paste = "1"
-rand = "0.9.1"
+paste = "1.0.15"
+rand = "0.9.2"
 rand_chacha = "0.9.0"
 seq-macro = "0.3.6"
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 validator = { version = "0.20.0", features = ["derive"] }
 zerocopy = { version = "0.8.26", features = ["derive"] }
 
@@ -91,10 +91,20 @@ rust.unused_macro_rules = "warn"
 rust.unused_qualifications = "warn"
 
 [profile.dev]
-lto = false
+codegen-units = 256
+lto = "off"
 opt-level = 1
+debug = "full"
+strip = "none"
 
 [profile.release]
 codegen-units = 1
-debug = true
 lto = "fat"
+opt-level = 3
+debug = "none"
+strip = "debuginfo"
+
+[profile.prof]
+inherits = "release"
+debug = "full"
+strip = "none"

--- a/crates/make/Cargo.toml
+++ b/crates/make/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-clap = { version = "4.5.38", features = ["derive"] }
+clap = { version = "4.5.41", features = ["derive"] }
 object = { version = "0.37.1", default-features = false, features = [
     "read",
     "wasm",

--- a/crates/make/src/main.rs
+++ b/crates/make/src/main.rs
@@ -178,7 +178,11 @@ fn build(
     }
     let mut result = PathBuf::from("./target");
     result.push(target);
-    result.push(if profile != "dev" { profile } else { "debug" });
+    result.push(match profile {
+        "dev" | "test" => "debug",
+        "release" | "bench" => "release",
+        profile => profile,
+    });
     result.push(format!("{}vchord{}", tsi.dll_prefix()?, tsi.dll_suffix()?));
     Ok(result)
 }
@@ -239,7 +243,11 @@ fn generate(
     }
     let mut result = PathBuf::from("./target");
     result.push(target);
-    result.push(if profile != "dev" { profile } else { "debug" });
+    result.push(match profile {
+        "dev" | "test" => "debug",
+        "release" | "bench" => "release",
+        profile => profile,
+    });
     result.push(format!("pgrx_embed_vchord{}", tsi.exe_suffix()?));
     let mut command;
     if !(tsi.is_unix && tsi.is_emscripten) {

--- a/crates/simd/Cargo.toml
+++ b/crates/simd/Cargo.toml
@@ -18,7 +18,7 @@ zerocopy.workspace = true
 rand.workspace = true
 
 [build-dependencies]
-cc = "1.2.27"
+cc = "1.2.30"
 which = "8.0.0"
 
 [lints]

--- a/crates/simd_macros/Cargo.toml
+++ b/crates/simd_macros/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 proc-macro = true
 
 [dependencies]
-proc-macro2 = { version = "1", features = ["proc-macro"] }
-quote = "1"
-syn = { version = "2", default-features = false, features = [
+proc-macro2 = { version = "1.0", features = ["proc-macro"] }
+quote = "1.0"
+syn = { version = "2.0", default-features = false, features = [
     "clone-impls",
     "full",
     "parsing",

--- a/crates/vchordrq/Cargo.toml
+++ b/crates/vchordrq/Cargo.toml
@@ -13,7 +13,7 @@ simd = { path = "../simd" }
 vector = { path = "../vector" }
 
 half.workspace = true
-pin-project = "1"
+pin-project = "1.1"
 serde.workspace = true
 validator.workspace = true
 zerocopy.workspace = true

--- a/taplo.toml
+++ b/taplo.toml
@@ -9,9 +9,7 @@ keys = [
     "build-dependencies",
     "target.*.dependencies",
     "lints",
-    "patch.*",
-    "profile.*",
     "workspace.dependencies",
-    "lints.dependencies",
+    "workspace.lints",
 ]
 formatting = { reorder_keys = true, reorder_arrays = true, align_comments = true }


### PR DESCRIPTION
Profile `release` includes debug information for profiling, while it unnecessarily increased the binary size for users. Now disable debuginfo for profile `release` and add a profile `prof` for profiling. The size of the release binary has been reduced from 96.9MB to 4.4MB.
