### PR TITLE
fix: apply same rotation on big endian

### DIFF
--- a/crates/rabitq/build.rs
+++ b/crates/rabitq/build.rs
@@ -20,7 +20,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha12Rng;
     let mut rng = ChaCha12Rng::from_seed([7; 32]);
-    let bits = (0..262144).map(|_| rng.random::<u8>()).collect::<Vec<_>>();
+    let mut bits = (0..262144).map(|_| rng.random::<u8>()).collect::<Vec<_>>();
+    if var("CARGO_CFG_TARGET_ENDIAN")?.as_str() == "big" {
+        for chunk in bits.as_chunks_mut::<8>().0 {
+            chunk.reverse();
+        }
+    }
     let out_dir = var("OUT_DIR")?;
     std::fs::write(PathBuf::from(out_dir).join("bits"), bits)?;
     Ok(())

--- a/crates/rabitq/src/rotate.rs
+++ b/crates/rabitq/src/rotate.rs
@@ -14,14 +14,29 @@
 
 const BITS: &[u8; 262144] = include_bytes!(concat!(env!("OUT_DIR"), "/bits"));
 
-const _: () = assert!(BITS[0] == 246);
-const _: () = assert!(BITS[1] == 133);
-const _: () = assert!(BITS[2] == 163);
-const _: () = assert!(BITS[3] == 106);
-const _: () = assert!(BITS[4] == 54);
-const _: () = assert!(BITS[5] == 126);
-const _: () = assert!(BITS[6] == 9);
-const _: () = assert!(BITS[7] == 115);
+#[cfg(target_endian = "little")]
+const _: () = {
+    assert!(BITS[0] == 246);
+    assert!(BITS[1] == 133);
+    assert!(BITS[2] == 163);
+    assert!(BITS[3] == 106);
+    assert!(BITS[4] == 54);
+    assert!(BITS[5] == 126);
+    assert!(BITS[6] == 9);
+    assert!(BITS[7] == 115);
+};
+
+#[cfg(target_endian = "big")]
+const _: () = {
+    assert!(BITS[7] == 246);
+    assert!(BITS[6] == 133);
+    assert!(BITS[5] == 163);
+    assert!(BITS[4] == 106);
+    assert!(BITS[3] == 54);
+    assert!(BITS[2] == 126);
+    assert!(BITS[1] == 9);
+    assert!(BITS[0] == 115);
+};
 
 static BITS_0: [u64; 1024] = zerocopy::transmute!(BITS.as_chunks::<8192>().0[0]);
 static BITS_1: [u64; 1024] = zerocopy::transmute!(BITS.as_chunks::<8192>().0[1]);


### PR DESCRIPTION
job: +check_debian