### PR TITLE
chore: multiple fixes and fast paths

### DIFF
--- a/crates/rabitq/src/bit.rs
+++ b/crates/rabitq/src/bit.rs
@@ -73,15 +73,9 @@ pub fn code(vector: &[f32]) -> Code {
         CodeMetadata {
             dis_u_2: sum_of_x_2,
             factor_cnt: {
-                let cnt_pos = vector
-                    .iter()
-                    .map(|x| x.is_sign_positive() as i32)
-                    .sum::<i32>();
-                let cnt_neg = vector
-                    .iter()
-                    .map(|x| x.is_sign_negative() as i32)
-                    .sum::<i32>();
-                (cnt_pos - cnt_neg) as f32
+                let cnt_pos = vector.iter().filter(|x| x.is_sign_positive()).count();
+                let cnt_neg = vector.iter().filter(|x| x.is_sign_negative()).count();
+                cnt_pos as f32 - cnt_neg as f32
             },
             factor_ip: sum_of_x_2 / sum_of_abs_x,
             factor_err: {

--- a/crates/rabitq/src/packing.rs
+++ b/crates/rabitq/src/packing.rs
@@ -101,14 +101,15 @@ pub fn any_pack<T: Default>(mut x: impl Iterator<Item = T>) -> [T; 32] {
     std::array::from_fn(|_| x.next()).map(|x| x.unwrap_or_default())
 }
 
-pub fn pack_to_u4(signs: &[bool]) -> Vec<u8> {
-    fn f(x: [bool; 4]) -> u8 {
-        x[0] as u8 | (x[1] as u8) << 1 | (x[2] as u8) << 2 | (x[3] as u8) << 3
-    }
-    let mut result = Vec::with_capacity(signs.len().div_ceil(4));
-    for i in 0..signs.len().div_ceil(4) {
-        let x = std::array::from_fn(|j| signs.get(i * 4 + j).copied().unwrap_or_default());
-        result.push(f(x));
-    }
-    result
+pub fn pack_to_u4(input: &[bool]) -> Vec<u8> {
+    let f = |t: &[bool; 4]| t[0] as u8 | (t[1] as u8) << 1 | (t[2] as u8) << 2 | (t[3] as u8) << 3;
+    let (arrays, remainder) = input.as_chunks::<4>();
+    let mut buffer = [false; 4];
+    let tailing = if !remainder.is_empty() {
+        buffer[..remainder.len()].copy_from_slice(remainder);
+        Some(&buffer)
+    } else {
+        None
+    };
+    arrays.iter().chain(tailing).map(f).collect()
 }

--- a/crates/vchordrq/src/bulkdelete.rs
+++ b/crates/vchordrq/src/bulkdelete.rs
@@ -43,7 +43,7 @@ pub fn bulkdelete<R: RelationRead + RelationWrite, O: Operator>(
         for first in state {
             tape::read_h1_tape::<R, _, _>(
                 by_next(index, first).inspect(|_| check()),
-                || FunctionalAccessor::new((), id_0(|_, _| ()), id_1(|_, _| [(); 32])),
+                || FunctionalAccessor::new((), id_0(|_, _| ()), id_1(|_, _| [(); _])),
                 |(), _, _, first, _| results.push(first),
             );
         }

--- a/crates/vchordrq/src/cache.rs
+++ b/crates/vchordrq/src/cache.rs
@@ -39,7 +39,7 @@ where
         for first in state {
             tape::read_h1_tape::<R, _, _>(
                 by_next(index, first).inspect(|guard| trace.push(guard.id())),
-                || FunctionalAccessor::new((), id_0(|_, _| ()), id_1(|_, _| [(); 32])),
+                || FunctionalAccessor::new((), id_0(|_, _| ()), id_1(|_, _| [(); _])),
                 |(), _, _, first, _| {
                     results.push(first);
                 },

--- a/crates/vchordrq/src/maintain.rs
+++ b/crates/vchordrq/src/maintain.rs
@@ -57,7 +57,7 @@ where
         for first in state {
             tape::read_h1_tape::<R, _, _>(
                 by_next(index, first).inspect(|_| check()),
-                || FunctionalAccessor::new((), id_0(|_, _| ()), id_1(|_, _| [(); 32])),
+                || FunctionalAccessor::new((), id_0(|_, _| ()), id_1(|_, _| [(); _])),
                 |(), _, _, first, _| results.push(first),
             );
         }

--- a/crates/vchordrq/src/prewarm.rs
+++ b/crates/vchordrq/src/prewarm.rs
@@ -64,7 +64,7 @@ where
         for first in state {
             tape::read_h1_tape::<R, _, _>(
                 by_next(index, first).inspect(|_| counter += 1),
-                || FunctionalAccessor::new((), id_0(|_, _| ()), id_1(|_, _| [(); 32])),
+                || FunctionalAccessor::new((), id_0(|_, _| ()), id_1(|_, _| [(); _])),
                 |(), head, _, first, prefetch| {
                     vectors::read_for_h1_tuple::<R, O, _>(
                         prefetch.iter().map(|&id| index.read(id)),
@@ -97,7 +97,7 @@ where
                     tape::read_directory_tape::<R>(by_next(index, jump_tuple.directory_first()));
                 tape::read_frozen_tape::<R, _, _>(
                     by_directory(&mut prefetch_h0_tuples, directory).inspect(|_| counter += 1),
-                    || FunctionalAccessor::new((), id_0(|_, _| ()), id_1(|_, _| [(); 32])),
+                    || FunctionalAccessor::new((), id_0(|_, _| ()), id_1(|_, _| [(); _])),
                     id_2(|_, _, _, _| {
                         results.push(());
                     }),
@@ -105,7 +105,7 @@ where
             } else {
                 tape::read_frozen_tape::<R, _, _>(
                     by_next(index, jump_tuple.frozen_first()).inspect(|_| counter += 1),
-                    || FunctionalAccessor::new((), id_0(|_, _| ()), id_1(|_, _| [(); 32])),
+                    || FunctionalAccessor::new((), id_0(|_, _| ()), id_1(|_, _| [(); _])),
                     id_2(|_, _, _, _| {
                         results.push(());
                     }),

--- a/crates/vchordrq/src/types.rs
+++ b/crates/vchordrq/src/types.rs
@@ -79,7 +79,7 @@ impl VectorKind {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Validate)]
 #[serde(deny_unknown_fields)]
 #[validate(schema(function = "Self::validate_self"))]
 pub struct VectorOptions {

--- a/src/index/vchordrq/am/mod.rs
+++ b/src/index/vchordrq/am/mod.rs
@@ -228,7 +228,7 @@ pub unsafe extern "C-unwind" fn amcostestimate(
                 let denumerator = r.clone();
                 let scale = r.skip(1).chain(std::iter::once(tuples));
                 for (scale, (numerator, denumerator)) in scale.zip(numerator.zip(denumerator)) {
-                    count += (scale as f64) * ((numerator as f64) / (denumerator as f64));
+                    count += (scale as f64) * 1.0f64.min((numerator as f64) / (denumerator as f64));
                 }
                 count
             };

--- a/src/index/vchordrq/types.rs
+++ b/src/index/vchordrq/types.rs
@@ -18,6 +18,17 @@ use vchordrq::types::VchordrqIndexOptions;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Validate)]
 #[serde(deny_unknown_fields)]
+pub struct VchordrqDefaultBuildOptions {}
+
+#[allow(clippy::derivable_impls)]
+impl Default for VchordrqDefaultBuildOptions {
+    fn default() -> Self {
+        Self {}
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+#[serde(deny_unknown_fields)]
 pub struct VchordrqInternalBuildOptions {
     #[serde(default = "VchordrqInternalBuildOptions::default_lists")]
     #[validate(length(min = 0, max = 8), custom(function = VchordrqInternalBuildOptions::validate_lists))]
@@ -84,13 +95,14 @@ pub struct VchordrqExternalBuildOptions {
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
 pub enum VchordrqBuildSourceOptions {
+    Default(VchordrqDefaultBuildOptions),
     Internal(VchordrqInternalBuildOptions),
     External(VchordrqExternalBuildOptions),
 }
 
 impl Default for VchordrqBuildSourceOptions {
     fn default() -> Self {
-        Self::Internal(Default::default())
+        Self::Default(Default::default())
     }
 }
 
@@ -98,6 +110,7 @@ impl Validate for VchordrqBuildSourceOptions {
     fn validate(&self) -> Result<(), ValidationErrors> {
         use VchordrqBuildSourceOptions::*;
         match self {
+            Default(default_build) => default_build.validate(),
             Internal(internal_build) => internal_build.validate(),
             External(external_build) => external_build.validate(),
         }

--- a/tests/vchordg/sequential_build.slt
+++ b/tests/vchordg/sequential_build.slt
@@ -1,0 +1,17 @@
+statement ok
+CREATE TABLE t (val vector(3));
+
+statement ok
+INSERT INTO t (val) SELECT ARRAY[random(), random(), random()]::real[] FROM generate_series(1, 1000);
+
+statement ok
+SET max_parallel_workers = 0;
+
+statement ok
+SET max_parallel_maintenance_workers = 0;
+
+statement ok
+CREATE INDEX ON t USING vchordg (val vector_ip_ops);
+
+statement ok
+DROP TABLE t;

--- a/tests/vchordrq/sequential_build.slt
+++ b/tests/vchordrq/sequential_build.slt
@@ -1,0 +1,24 @@
+statement ok
+CREATE TABLE t (val vector(3));
+
+statement ok
+INSERT INTO t (val) SELECT ARRAY[random(), random(), random()]::real[] FROM generate_series(1, 1000);
+
+statement ok
+SET max_parallel_workers = 0;
+
+statement ok
+SET max_parallel_maintenance_workers = 0;
+
+statement ok
+CREATE INDEX ON t USING vchordrq (val vector_ip_ops)
+WITH (options = $$
+residual_quantization = false
+build.pin = true
+build.internal.lists = [32]
+build.internal.build_threads = 2
+build.internal.spherical_centroids = true
+$$);
+
+statement ok
+DROP TABLE t;


### PR DESCRIPTION
1. fixes `build.pin` does not work if the build is not parallelized
2. adds fast path if `lists <= probes && !residual_quantization`
3. fixes cost estimation if `lists < probes`
4. adds `build.default` to reduce special handling
5. rotate vectors after all kinds of `build` to reduce special handling