### PR TITLE
perf: reduce lock contention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "bindgen"
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.3"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bitvec"
@@ -151,15 +151,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
- "toml 0.9.5",
+ "toml 0.9.7",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.34"
+version = "1.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
+checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -201,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.46"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -211,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.46"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -223,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.45"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -331,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "dary_heap"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d2cd9c18b9f454ed67da600630b021a8a80bf33f8c95896ab33aaf1c26b728"
+checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
 
 [[package]]
 name = "displaydoc"
@@ -402,12 +403,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -431,6 +432,12 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "fixedbitset"
@@ -512,12 +519,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -662,12 +675,12 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -710,9 +723,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -730,18 +743,18 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libloading"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -767,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -779,9 +792,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "make"
@@ -891,7 +904,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
 dependencies = [
  "fixedbitset",
- "hashbrown",
+ "hashbrown 0.15.5",
  "indexmap",
  "serde",
 ]
@@ -1039,9 +1052,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
@@ -1217,15 +1230,15 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1263,10 +1276,11 @@ checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -1281,10 +1295,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1293,14 +1316,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1314,11 +1338,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+checksum = "5417783452c2be558477e104686f7de5dae53dba813c28435e0e70f82d9b04ee"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1474,14 +1498,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+checksum = "00e5e5d9bf2475ac9d4f0d9edab68cc573dc2fd644b0dba36b0c30a92dd9eaa0"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned 1.0.0",
- "toml_datetime 0.7.0",
+ "serde_core",
+ "serde_spanned 1.0.2",
+ "toml_datetime 0.7.2",
  "toml_parser",
  "toml_writer",
  "winnow",
@@ -1498,11 +1522,11 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1521,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
 dependencies = [
  "winnow",
 ]
@@ -1536,9 +1560,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+checksum = "d163a63c116ce562a22cda521fcc4d79152e7aba014456fb5eb442f6d6a10109"
 
 [[package]]
 name = "unescape"
@@ -1548,9 +1572,9 @@ checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1590,9 +1614,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "getrandom",
  "js-sys",
@@ -1650,7 +1674,7 @@ dependencies = [
  "serde",
  "simd",
  "small_iter",
- "toml 0.9.5",
+ "toml 0.9.7",
  "validator",
  "vchordg",
  "vchordrq",
@@ -1718,30 +1742,40 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
- "wit-bindgen-rt",
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
 dependencies = [
  "bumpalo",
  "log",
@@ -1753,9 +1787,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1763,9 +1797,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1776,9 +1810,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
 dependencies = [
  "unicode-ident",
 ]
@@ -1821,11 +1855,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1839,6 +1873,12 @@ name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-sys"
@@ -1856,6 +1896,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -1880,7 +1929,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -2003,13 +2052,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
@@ -2052,18 +2098,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/algo/src/lib.rs
+++ b/crates/algo/src/lib.rs
@@ -92,14 +92,6 @@ pub trait RelationWrite: RelationWriteTypes {
     fn search(&self, freespace: usize) -> Option<Self::WriteGuard<'_>>;
 }
 
-pub trait RelationLength: Relation {
-    fn len(&self) -> u32;
-    #[inline]
-    fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-}
-
 pub trait RelationPrefetch: Relation {
     fn prefetch(&self, id: u32);
 }

--- a/crates/vchordg/src/bulkdelete.rs
+++ b/crates/vchordg/src/bulkdelete.rs
@@ -15,10 +15,10 @@
 use crate::Opaque;
 use crate::operator::Operator;
 use crate::tuples::{MetaTuple, VertexTuple, WithReader, WithWriter};
-use algo::{Page, RelationLength, RelationRead, RelationWrite};
+use algo::{Page, RelationRead, RelationWrite};
 use std::num::NonZero;
 
-pub fn bulkdelete<R: RelationRead + RelationWrite + RelationLength, O: Operator>(
+pub fn bulkdelete<R: RelationRead + RelationWrite, O: Operator>(
     index: &R,
     check: impl Fn(),
     callback: impl Fn(NonZero<u64>) -> bool,

--- a/crates/vchordg/src/types.rs
+++ b/crates/vchordg/src/types.rs
@@ -92,14 +92,14 @@ pub enum BorrowedVector<'a> {
 }
 
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum DistanceKind {
     L2S,
     Dot,
 }
 
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum VectorKind {
     Vecf32,
     Vecf16,
@@ -114,16 +114,12 @@ impl VectorKind {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone, Validate)]
 #[validate(schema(function = "Self::validate_self"))]
 pub struct VectorOptions {
     #[validate(range(min = 1))]
-    #[serde(rename = "dimensions")]
     pub dims: u32,
-    #[serde(rename = "vector")]
     pub v: VectorKind,
-    #[serde(rename = "distance")]
     pub d: DistanceKind,
 }
 

--- a/crates/vchordrq/src/cache.rs
+++ b/crates/vchordrq/src/cache.rs
@@ -19,41 +19,59 @@ use crate::{Opaque, Page, PageGuard, tape};
 use algo::RelationRead;
 use algo::accessor::FunctionalAccessor;
 
-pub fn cache<R: RelationRead>(index: &R) -> Vec<u32>
+pub fn cache<R: RelationRead>(index: &R, level: i32) -> Vec<u32>
 where
     R::Page: Page<Opaque = Opaque>,
 {
-    let mut trace = vec![0_u32];
     let meta_guard = index.read(0);
     let meta_bytes = meta_guard.get(1).expect("data corruption");
     let meta_tuple = MetaTuple::deserialize_ref(meta_bytes);
     let height_of_root = meta_tuple.height_of_root();
+    let centroids_first = meta_tuple.centroids_first();
 
     type State = Vec<u32>;
     let mut state: State = vec![meta_tuple.first()];
 
     drop(meta_guard);
 
-    let mut step = |state: State| {
-        let mut results = Vec::new();
-        for first in state {
-            tape::read_h1_tape::<R, _, _>(
-                by_next(index, first).inspect(|guard| trace.push(guard.id())),
-                || FunctionalAccessor::new((), id_0(|_, _| ()), id_1(|_, _| [(); _])),
-                |(), _, _, first, _| {
-                    results.push(first);
-                },
-            );
-        }
-        results
-    };
+    let mut trace = Vec::new();
 
-    for _ in (1..height_of_root).rev() {
-        state = step(state);
+    if level >= 0 {
+        // meta tuple
+        trace.push(0);
     }
 
-    for first in state {
-        trace.push(first);
+    if level >= 1 {
+        let mut step = |state: State| {
+            let mut results = Vec::new();
+            for first in state {
+                tape::read_h1_tape::<R, _, _>(
+                    by_next(index, first).inspect(|guard| trace.push(guard.id())),
+                    || FunctionalAccessor::new((), id_0(|_, _| ()), id_1(|_, _| [(); _])),
+                    |(), _, _, first, _| {
+                        results.push(first);
+                    },
+                );
+            }
+            results
+        };
+
+        // h1 tuples
+        for _ in (1..height_of_root).rev() {
+            state = step(state);
+        }
+
+        // jump tuples
+        for first in state {
+            trace.push(first);
+        }
+    }
+
+    if level >= 2 {
+        // centroid tuples
+        for guard in by_next(index, centroids_first) {
+            trace.push(guard.id());
+        }
     }
 
     trace

--- a/crates/vchordrq/src/centroids.rs
+++ b/crates/vchordrq/src/centroids.rs
@@ -1,0 +1,44 @@
+// This software is licensed under a dual license model:
+//
+// GNU Affero General Public License v3 (AGPLv3): You may use, modify, and
+// distribute this software under the terms of the AGPLv3.
+//
+// Elastic License v2 (ELv2): You may also use, modify, and distribute this
+// software under the Elastic License v2, which has specific restrictions.
+//
+// We welcome any commercial collaboration or support. For inquiries
+// regarding the licenses, please contact us at:
+// vectorchord-inquiry@tensorchord.ai
+//
+// Copyright (c) 2025 TensorChord Inc.
+
+use crate::Page;
+use crate::operator::*;
+use crate::tuples::*;
+use algo::RelationRead;
+use algo::accessor::Accessor1;
+
+pub fn read<
+    'a,
+    R: RelationRead + 'a,
+    O: Operator,
+    A: Accessor1<<O::Vector as Vector>::Element, <O::Vector as Vector>::Metadata>,
+>(
+    mut prefetch: impl Iterator<Item = R::ReadGuard<'a>>,
+    head: u16,
+    accessor: A,
+) -> A::Output {
+    let mut cursor = Err(head);
+    let mut result = accessor;
+    while let Err(head) = cursor {
+        let guard = prefetch.next().expect("data corruption");
+        let bytes = guard.get(head).expect("data corruption");
+        let tuple = CentroidTuple::<O::Vector>::deserialize_ref(bytes);
+        result.push(tuple.elements());
+        cursor = tuple.metadata_or_head();
+    }
+    if prefetch.next().is_some() {
+        panic!("data corruption");
+    }
+    result.finish(cursor.expect("data corruption"))
+}

--- a/crates/vchordrq/src/lib.rs
+++ b/crates/vchordrq/src/lib.rs
@@ -15,6 +15,7 @@
 mod build;
 mod bulkdelete;
 mod cache;
+mod centroids;
 mod closure_lifetime_binder;
 mod cost;
 mod fast_heap;
@@ -44,6 +45,7 @@ pub use maintain::maintain;
 pub use prewarm::prewarm;
 pub use rerank::{how, rerank_heap, rerank_index};
 pub use search::{default_search, maxsim_search};
+use std::num::NonZero;
 
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
@@ -64,4 +66,8 @@ pub(crate) struct Branch<T> {
     pub head: u16,
     pub norm: f32,
     pub extra: T,
+}
+
+pub trait Chooser {
+    fn choose(&mut self, n: NonZero<usize>) -> usize;
 }

--- a/crates/vchordrq/src/prewarm.rs
+++ b/crates/vchordrq/src/prewarm.rs
@@ -16,7 +16,7 @@ use crate::closure_lifetime_binder::{id_0, id_1, id_2};
 use crate::operator::Operator;
 use crate::tape::{by_directory, by_next};
 use crate::tuples::*;
-use crate::{Opaque, Page, tape, vectors};
+use crate::{Opaque, Page, centroids, tape};
 use algo::RelationRead;
 use algo::accessor::FunctionalAccessor;
 use algo::prefetcher::PrefetcherSequenceFamily;
@@ -48,7 +48,7 @@ where
         let prefetch = meta_tuple.centroid_prefetch().to_vec().into_iter();
         let head = meta_tuple.centroid_head();
         let first = meta_tuple.first();
-        vectors::read_for_h1_tuple::<R, O, _>(prefetch.map(|id| index.read(id)), head, ());
+        centroids::read::<R, O, _>(prefetch.map(|id| index.read(id)), head, ());
         results.push(first);
         writeln!(message, "------------------------").unwrap();
         writeln!(message, "number of nodes: {}", results.len()).unwrap();
@@ -66,11 +66,7 @@ where
                 by_next(index, first).inspect(|_| counter += 1),
                 || FunctionalAccessor::new((), id_0(|_, _| ()), id_1(|_, _| [(); _])),
                 |(), head, _, first, prefetch| {
-                    vectors::read_for_h1_tuple::<R, O, _>(
-                        prefetch.iter().map(|&id| index.read(id)),
-                        head,
-                        (),
-                    );
+                    centroids::read::<R, O, _>(prefetch.iter().map(|&id| index.read(id)), head, ());
                     results.push(first);
                 },
             );

--- a/crates/vchordrq/src/rerank.rs
+++ b/crates/vchordrq/src/rerank.rs
@@ -91,7 +91,7 @@ pub fn rerank_index<
         prefetcher,
         cache: BinaryHeap::new(),
         f: id_4::<_, P, _, _, _>(move |payload, prefetch, head| {
-            vectors::read_for_h0_tuple::<P::R, O, _>(
+            vectors::read::<P::R, O, _>(
                 prefetch,
                 head,
                 payload,

--- a/crates/vchordrq/src/search.rs
+++ b/crates/vchordrq/src/search.rs
@@ -17,7 +17,7 @@ use crate::linked_vec::LinkedVec;
 use crate::operator::*;
 use crate::tape::{by_directory, by_next};
 use crate::tuples::*;
-use crate::{Opaque, Page, tape, vectors};
+use crate::{Opaque, Page, centroids, tape};
 use algo::accessor::{FunctionalAccessor, LAccess};
 use algo::prefetcher::{Prefetcher, PrefetcherHeapFamily, PrefetcherSequenceFamily};
 use algo::{BorrowedIter, Bump, PackedRefMut4, PackedRefMut8, RelationRead};
@@ -67,7 +67,7 @@ where
         let prefetch =
             BorrowedIter::from_slice(meta_tuple.centroid_prefetch(), |x| bump.alloc_slice(x));
         let head = meta_tuple.centroid_head();
-        let distance = vectors::read_for_h1_tuple::<R, O, _>(
+        let distance = centroids::read::<R, O, _>(
             prefetch.map(|id| index.read(id)),
             head,
             LAccess::new(O::Vector::unpack(vector), O::DistanceAccessor::default()),
@@ -112,7 +112,7 @@ where
             while let Some(((Reverse(_), AlwaysEqual(&mut (first, norm, head, ..))), prefetch)) =
                 heap.next_if(|(d, _)| Some(*d) > cache.peek().map(|(d, ..)| *d))
             {
-                let distance = vectors::read_for_h1_tuple::<R, O, _>(
+                let distance = centroids::read::<R, O, _>(
                     prefetch,
                     head,
                     LAccess::new(O::Vector::unpack(vector), O::DistanceAccessor::default()),
@@ -228,7 +228,7 @@ where
         let prefetch =
             BorrowedIter::from_slice(meta_tuple.centroid_prefetch(), |x| bump.alloc_slice(x));
         let head = meta_tuple.centroid_head();
-        let distance = vectors::read_for_h1_tuple::<R, O, _>(
+        let distance = centroids::read::<R, O, _>(
             prefetch.map(|id| index.read(id)),
             head,
             LAccess::new(O::Vector::unpack(vector), O::DistanceAccessor::default()),
@@ -273,7 +273,7 @@ where
             while let Some(((Reverse(_), AlwaysEqual(&mut (first, norm, head, ..))), prefetch)) =
                 heap.next_if(|(d, _)| Some(*d) > cache.peek().map(|(d, ..)| *d))
             {
-                let distance = vectors::read_for_h1_tuple::<R, O, _>(
+                let distance = centroids::read::<R, O, _>(
                     prefetch,
                     head,
                     LAccess::new(O::Vector::unpack(vector), O::DistanceAccessor::default()),

--- a/crates/vchordrq/src/types.rs
+++ b/crates/vchordrq/src/types.rs
@@ -24,6 +24,9 @@ pub struct VchordrqIndexOptions {
     pub residual_quantization: bool,
     #[serde(default = "VchordrqIndexOptions::default_rerank_in_table")]
     pub rerank_in_table: bool,
+    #[serde(default = "VchordrqIndexOptions::default_degree_of_parallelism")]
+    #[validate(range(min = 1, max = 256))]
+    pub degree_of_parallelism: u32,
 }
 
 impl VchordrqIndexOptions {
@@ -33,6 +36,9 @@ impl VchordrqIndexOptions {
     fn default_rerank_in_table() -> bool {
         false
     }
+    fn default_degree_of_parallelism() -> u32 {
+        32
+    }
 }
 
 impl Default for VchordrqIndexOptions {
@@ -40,6 +46,7 @@ impl Default for VchordrqIndexOptions {
         Self {
             residual_quantization: Self::default_residual_quantization(),
             rerank_in_table: Self::default_rerank_in_table(),
+            degree_of_parallelism: Self::default_degree_of_parallelism(),
         }
     }
 }
@@ -57,14 +64,14 @@ pub enum BorrowedVector<'a> {
 }
 
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum DistanceKind {
     L2S,
     Dot,
 }
 
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum VectorKind {
     Vecf32,
     Vecf16,
@@ -79,16 +86,12 @@ impl VectorKind {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Validate)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone, Copy, Validate)]
 #[validate(schema(function = "Self::validate_self"))]
 pub struct VectorOptions {
     #[validate(range(min = 1))]
-    #[serde(rename = "dimensions")]
     pub dims: u32,
-    #[serde(rename = "vector")]
     pub v: VectorKind,
-    #[serde(rename = "distance")]
     pub d: DistanceKind,
 }
 

--- a/src/datatype/typmod.rs
+++ b/src/datatype/typmod.rs
@@ -12,11 +12,10 @@
 //
 // Copyright (c) 2025 TensorChord Inc.
 
-use serde::{Deserialize, Serialize};
 use std::ffi::{CStr, CString};
 use std::num::NonZero;
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy)]
 pub enum Typmod {
     Any,
     Dims(NonZero<u32>),

--- a/src/index/vchordg/algo.rs
+++ b/src/index/vchordg/algo.rs
@@ -51,7 +51,7 @@ pub fn bulkdelete<R>(
     check: impl Fn(),
     callback: impl Fn(NonZero<u64>) -> bool,
 ) where
-    R: RelationRead + RelationWrite + RelationLength,
+    R: RelationRead + RelationWrite,
     R::Page: Page<Opaque = Opaque>,
 {
     match (opfamily.vector_kind(), opfamily.distance_kind()) {

--- a/src/index/vchordrq/algo.rs
+++ b/src/index/vchordrq/algo.rs
@@ -22,7 +22,7 @@ use std::collections::BinaryHeap;
 use std::num::NonZero;
 use vchordrq::operator::Op;
 use vchordrq::types::*;
-use vchordrq::{FastHeap, Opaque};
+use vchordrq::{Chooser, FastHeap, Opaque};
 use vector::VectorOwned;
 use vector::vect::{VectBorrowed, VectOwned};
 
@@ -154,11 +154,13 @@ pub fn insert<R>(
     payload: NonZero<u64>,
     vector: OwnedVector,
     skip_freespaces: bool,
+    skip_search: bool,
+    chooser: &mut impl Chooser,
+    bump: &impl Bump,
 ) where
     R: RelationRead + RelationWrite,
     R::Page: Page<Opaque = Opaque>,
 {
-    let bump = bumpalo::Bump::new();
     let make_h1_plain_prefetcher = MakeH1PlainPrefetcherForInsertion { index };
     match (vector, opfamily.distance_kind()) {
         (OwnedVector::Vecf32(vector), DistanceKind::L2S) => {
@@ -168,13 +170,15 @@ pub fn insert<R>(
                 index,
                 payload,
                 vector.as_borrowed(),
+                chooser,
+                skip_search,
             );
             vchordrq::insert::<_, Op<VectOwned<f32>, L2S>>(
                 index,
                 payload,
                 projected.as_borrowed(),
                 key,
-                &bump,
+                bump,
                 make_h1_plain_prefetcher,
                 skip_freespaces,
             )
@@ -186,13 +190,15 @@ pub fn insert<R>(
                 index,
                 payload,
                 vector.as_borrowed(),
+                chooser,
+                skip_search,
             );
             vchordrq::insert::<_, Op<VectOwned<f32>, Dot>>(
                 index,
                 payload,
                 projected.as_borrowed(),
                 key,
-                &bump,
+                bump,
                 make_h1_plain_prefetcher,
                 skip_freespaces,
             )
@@ -204,13 +210,15 @@ pub fn insert<R>(
                 index,
                 payload,
                 vector.as_borrowed(),
+                chooser,
+                skip_search,
             );
             vchordrq::insert::<_, Op<VectOwned<f16>, L2S>>(
                 index,
                 payload,
                 projected.as_borrowed(),
                 key,
-                &bump,
+                bump,
                 make_h1_plain_prefetcher,
                 skip_freespaces,
             )
@@ -222,13 +230,15 @@ pub fn insert<R>(
                 index,
                 payload,
                 vector.as_borrowed(),
+                chooser,
+                skip_search,
             );
             vchordrq::insert::<_, Op<VectOwned<f16>, Dot>>(
                 index,
                 payload,
                 projected.as_borrowed(),
                 key,
-                &bump,
+                bump,
                 make_h1_plain_prefetcher,
                 skip_freespaces,
             )

--- a/src/index/vchordrq/types.rs
+++ b/src/index/vchordrq/types.rs
@@ -119,18 +119,34 @@ impl Validate for VchordrqBuildSourceOptions {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, Validate)]
 #[serde(deny_unknown_fields)]
-#[serde(rename_all = "snake_case")]
 pub struct VchordrqBuildOptions {
     #[serde(flatten)]
     #[validate(nested)]
     pub source: VchordrqBuildSourceOptions,
+    #[serde(deserialize_with = "VchordrqBuildOptions::deserialize_pin")]
     #[serde(default = "VchordrqBuildOptions::default_pin")]
-    pub pin: bool,
+    #[validate(range(min = -1, max = 2))]
+    pub pin: i32,
 }
 
 impl VchordrqBuildOptions {
-    pub fn default_pin() -> bool {
-        false
+    pub fn deserialize_pin<'de, D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<i32, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Untagged {
+            Bool(bool),
+            I32(i32),
+        }
+
+        match Untagged::deserialize(deserializer)? {
+            Untagged::Bool(b) => Ok(if b { 1 } else { -1 }),
+            Untagged::I32(i) => Ok(i),
+        }
+    }
+    pub fn default_pin() -> i32 {
+        -1
     }
 }
 


### PR DESCRIPTION
```sql
create index on laion1m768_train using vchordrq (embedding vector_ip_ops) with (options = $$
build.pin = 2
build.internal.lists = [256, 4096]
build.internal.build_threads = 20
build.internal.spherical_centroids = true
degree_of_parallelism = 40
$$);
```

`degree_of_parallelism` is 32 by default. It reduces lock contention during insertion, especially, in a build where `lists.len() != 1`.

`build.pin` is `-1` by default. `build.pin = 2` caches almost everything in memory, which speeds build but spends more memory. `build.pin = false` and `build.pin = true` still works, and they're mapped to `build.pin = -1` and `build.pin = 1`.