### PR TITLE
chore: strip symbols in profile release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ codegen-units = 1
 lto = "fat"
 opt-level = 3
 debug = "none"
-strip = "debuginfo"
+strip = "symbols"
 
 [profile.prof]
 inherits = "release"


### PR DESCRIPTION
It reduces the size of the release binary by 16.5% (with `-Csymbol-mangling-version=v0`). It prevent users from getting the error's backtrace. PostgreSQL errors do not show a backtrace by default, so it is not an issue.