### PR TITLE
chore: don't use clang by default for simd c shim

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -124,6 +124,11 @@ jobs:
           rustup default nightly
           rustup component add miri
 
+      - name: Install Clang
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://apt.llvm.org/llvm.sh | sudo bash -s -- 18
+          echo CC=clang-18 >> $GITHUB_ENV
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -173,6 +178,11 @@ jobs:
 
       - name: Install Rust
         run: rustup update
+
+      - name: Install Clang
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://apt.llvm.org/llvm.sh | sudo bash -s -- 18
+          echo CC=clang-18 >> $GITHUB_ENV
 
       - name: Set up Sccache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -238,7 +248,7 @@ jobs:
       - name: Install Clang
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://apt.llvm.org/llvm.sh | sudo bash -s -- 18
-          sudo update-alternatives --install /usr/bin/clang clang $(which clang-18) 255
+          echo CC=clang-18 >> $GITHUB_ENV
 
       - name: Install PostgreSQL & pgvector
         run: |

--- a/crates/simd/build.rs
+++ b/crates/simd/build.rs
@@ -14,69 +14,19 @@
 
 use std::env::var;
 use std::error::Error;
-use std::ffi::OsString;
-use std::path::Path;
-
-fn compiler_version(cc: impl AsRef<Path>) -> Option<u16> {
-    let cc = cc.as_ref();
-    if let Ok(r) = std::process::Command::new(cc).arg("-dumpversion").output()
-        && r.status.success()
-        && let Some(major) = r.stdout.split(|c| !c.is_ascii_digit()).next()
-        && let Ok(major) = std::str::from_utf8(major)
-        && let Ok(major) = major.parse::<u16>()
-    {
-        return Some(major);
-    }
-    None
-}
-
-fn compiler(host: &str, target: &str, clang_version: u16, gcc_version: u16) -> Option<OsString> {
-    let keys = [
-        &format!("CC_{target}"),
-        &format!("CC_{}", target.replace("-", "_")),
-        "TARGET_CC",
-        "CC",
-    ];
-    if keys.iter().any(|key| std::env::var_os(key).is_some()) {
-        return None;
-    }
-    if host == target {
-        if let Ok(cc) = which::which("clang")
-            && compiler_version(&cc) >= Some(clang_version)
-        {
-            return Some(cc.into());
-        }
-        if let Ok(cc) = which::which("gcc")
-            && compiler_version(&cc) >= Some(gcc_version)
-        {
-            return Some(cc.into());
-        }
-    }
-    None
-}
 
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo::rerun-if-changed=cshim");
-    let host = var("HOST")?;
-    let target = var("TARGET")?;
     let target_arch = var("CARGO_CFG_TARGET_ARCH")?;
     match target_arch.as_str() {
         "aarch64" => {
             let mut build = cc::Build::new();
-            if let Some(compiler) = compiler(&host, &target, 16, 14) {
-                build.compiler(compiler);
-            }
             build.file("./cshim/aarch64.c");
             build.opt_level(3);
             build.compile("simd_cshim");
         }
-        "powerpc64" => {}
-        "s390x" => {}
         "x86_64" => {
             let mut build = cc::Build::new();
-            if let Some(compiler) = compiler(&host, &target, 16, 12) {
-                build.compiler(compiler);
-            }
             build.file("./cshim/x86_64.c");
             build.opt_level(3);
             build.compile("simd_cshim");


### PR DESCRIPTION
Some C code is compiled with system's C compiler by default, while SIMD C shim is compiled with Clang by default, which causes issues when using LTO for packaging. Therefore, compile all C code with system's C compiler.