### PR TITLE
feat: allow setting index in `vchordrq.probes`

### DIFF
--- a/src/index/storage.rs
+++ b/src/index/storage.rs
@@ -272,6 +272,9 @@ impl<Opaque> PostgresRelation<Opaque> {
             _phantom: PhantomData,
         }
     }
+    pub fn raw(&self) -> pgrx::pg_sys::Relation {
+        self.raw
+    }
 }
 
 impl<O: Opaque> Relation for PostgresRelation<O> {


### PR DESCRIPTION
https://github.com/tensorchord/VectorChord/issues/392

Usage:

```sql
SET vchordrq.probes to 'laion1m768_train_embedding_idx:30;';
-- set `vchordrq.probes` to `30`, for the index `laion1m768_train_embedding`
-- set `vchordrq.probes` to `` for other indexes

SELECT set_config('vchordrq.probes', 'laion1m768_train_embedding_idx:30;' || current_setting('vchordrq.probes'), true);
-- in a transaction, to override config and keep config for other indexes work
```

1. should this apply to other GUCs?

```
vchordrq.enable_scan
vchordrq.probes
vchordrq.epsilon
vchordrq.max_scan_tuples
vchordrq.maxsim_refine
vchordrq.maxsim_threshold
vchordrq.prefilter
vchordrq.io_search
vchordrq.io_rerank
vchordrq.query_sampling_enable
vchordrq.query_sampling_max_records
vchordrq.query_sampling_rate
vchordg.enable_scan
vchordg.ef_search
vchordg.beam_search
vchordg.max_scan_tuples
vchordg.io_search
vchordg.io_rerank
```

2. should schema name, even database name be allowed as a part of index name here?

```sql
SET vchordrq.probes to 'public.laion1m768_train_embedding_idx:30;';
-- set `vchordrq.probes` to `30`, for the index `public.laion1m768_train_embedding`
-- set `vchordrq.probes` to `` for other indexes
SET vchordrq.probes to 'postgres.public.laion1m768_train_embedding_idx:30;';
-- set `vchordrq.probes` to `30`, for the index `public.laion1m768_train_embedding` in database `postgres`
-- set `vchordrq.probes` to `` for other indexes
```

3. Is default setting for each index a better way?

```sql
CREATE index on t using vchordrq (embedding vector_ip_ops) with (probes = '30');
SET vchordrq.probes TO DEFAULT; -- removes value to use default value in index options
```