### PR TITLE
feat: specify search parameters in index options

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -361,6 +361,8 @@ jobs:
 
       - name: Set up Sccache
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        with:
+          version: "v0.12.0"
 
       - name: Install PostgreSQL & pgvector
         run: |
@@ -559,6 +561,7 @@ jobs:
       volumes:
         - /opt:/opt:rw,rshared
         - /opt:/__e/node20:ro,rshared
+        - /opt:/__e/node24:ro,rshared
 
     env:
       SCCACHE_GHA_ENABLED: "true"

--- a/crates/simd/src/emulate.rs
+++ b/crates/simd/src/emulate.rs
@@ -12,6 +12,7 @@
 //
 // Copyright (c) 2025 TensorChord Inc.
 
+#[allow(unused_macros)]
 macro_rules! partial_load {
     (@internal_0) => {
         ::core::mem::zeroed()
@@ -37,6 +38,7 @@ macro_rules! partial_load {
     };
 }
 
+#[allow(unused_imports)]
 pub(crate) use partial_load;
 
 // VP2INTERSECT emulation.

--- a/crates/simd/src/fast_scan.rs
+++ b/crates/simd/src/fast_scan.rs
@@ -165,13 +165,15 @@ mod scan {
             return;
         }
         for _ in 0..if cfg!(not(miri)) { 256 } else { 1 } {
+            let code = (0..110)
+                .map(|_| std::array::from_fn(|_| rand::random()))
+                .collect::<Vec<[u8; 16]>>();
+            let lut = (0..110)
+                .map(|_| std::array::from_fn(|_| rand::random()))
+                .collect::<Vec<[u8; 16]>>();
             for n in 90..110 {
-                let code = (0..n)
-                    .map(|_| std::array::from_fn(|_| rand::random()))
-                    .collect::<Vec<[u8; 16]>>();
-                let lut = (0..n)
-                    .map(|_| std::array::from_fn(|_| rand::random()))
-                    .collect::<Vec<[u8; 16]>>();
+                let code = &code[..n];
+                let lut = &lut[..n];
                 unsafe {
                     assert_eq!(scan_v4(&code, &lut), fallback(&code, &lut));
                 }
@@ -268,13 +270,15 @@ mod scan {
             return;
         }
         for _ in 0..if cfg!(not(miri)) { 256 } else { 1 } {
+            let code = (0..110)
+                .map(|_| std::array::from_fn(|_| rand::random()))
+                .collect::<Vec<[u8; 16]>>();
+            let lut = (0..110)
+                .map(|_| std::array::from_fn(|_| rand::random()))
+                .collect::<Vec<[u8; 16]>>();
             for n in 90..110 {
-                let code = (0..n)
-                    .map(|_| std::array::from_fn(|_| rand::random()))
-                    .collect::<Vec<[u8; 16]>>();
-                let lut = (0..n)
-                    .map(|_| std::array::from_fn(|_| rand::random()))
-                    .collect::<Vec<[u8; 16]>>();
+                let code = &code[..n];
+                let lut = &lut[..n];
                 unsafe {
                     assert_eq!(scan_v3(&code, &lut), fallback(&code, &lut));
                 }
@@ -341,13 +345,15 @@ mod scan {
             return;
         }
         for _ in 0..if cfg!(not(miri)) { 256 } else { 1 } {
+            let code = (0..110)
+                .map(|_| std::array::from_fn(|_| rand::random()))
+                .collect::<Vec<[u8; 16]>>();
+            let lut = (0..110)
+                .map(|_| std::array::from_fn(|_| rand::random()))
+                .collect::<Vec<[u8; 16]>>();
             for n in 90..110 {
-                let code = (0..n)
-                    .map(|_| std::array::from_fn(|_| rand::random()))
-                    .collect::<Vec<[u8; 16]>>();
-                let lut = (0..n)
-                    .map(|_| std::array::from_fn(|_| rand::random()))
-                    .collect::<Vec<[u8; 16]>>();
+                let code = &code[..n];
+                let lut = &lut[..n];
                 unsafe {
                     assert_eq!(scan_v2(&code, &lut), fallback(&code, &lut));
                 }
@@ -414,13 +420,15 @@ mod scan {
             return;
         }
         for _ in 0..if cfg!(not(miri)) { 256 } else { 1 } {
+            let code = (0..110)
+                .map(|_| std::array::from_fn(|_| rand::random()))
+                .collect::<Vec<[u8; 16]>>();
+            let lut = (0..110)
+                .map(|_| std::array::from_fn(|_| rand::random()))
+                .collect::<Vec<[u8; 16]>>();
             for n in 90..110 {
-                let code = (0..n)
-                    .map(|_| std::array::from_fn(|_| rand::random()))
-                    .collect::<Vec<[u8; 16]>>();
-                let lut = (0..n)
-                    .map(|_| std::array::from_fn(|_| rand::random()))
-                    .collect::<Vec<[u8; 16]>>();
+                let code = &code[..n];
+                let lut = &lut[..n];
                 unsafe {
                     assert_eq!(scan_a2(&code, &lut), fallback(&code, &lut));
                 }
@@ -486,20 +494,22 @@ mod scan {
 
     #[cfg(all(target_arch = "s390x", test))]
     #[test]
-    #[cfg(miri, ignore)]
+    #[cfg_attr(miri, ignore)]
     fn scan_z13_test() {
         if !crate::is_cpu_detected!("z13") {
             println!("test {} ... skipped (z13)", module_path!());
             return;
         }
         for _ in 0..if cfg!(not(miri)) { 256 } else { 1 } {
+            let code = (0..110)
+                .map(|_| std::array::from_fn(|_| rand::random()))
+                .collect::<Vec<[u8; 16]>>();
+            let lut = (0..110)
+                .map(|_| std::array::from_fn(|_| rand::random()))
+                .collect::<Vec<[u8; 16]>>();
             for n in 90..110 {
-                let code = (0..n)
-                    .map(|_| std::array::from_fn(|_| rand::random()))
-                    .collect::<Vec<[u8; 16]>>();
-                let lut = (0..n)
-                    .map(|_| std::array::from_fn(|_| rand::random()))
-                    .collect::<Vec<[u8; 16]>>();
+                let code = &code[..n];
+                let lut = &lut[..n];
                 unsafe {
                     assert_eq!(scan_z13(&code, &lut), fallback(&code, &lut));
                 }
@@ -608,20 +618,22 @@ mod scan {
 
     #[cfg(all(target_arch = "powerpc64", test))]
     #[test]
-    #[cfg(miri, ignore)]
+    #[cfg_attr(miri, ignore)]
     fn scan_p9_test() {
         if !crate::is_cpu_detected!("p9") {
             println!("test {} ... skipped (p9)", module_path!());
             return;
         }
         for _ in 0..if cfg!(not(miri)) { 256 } else { 1 } {
+            let code = (0..110)
+                .map(|_| std::array::from_fn(|_| rand::random()))
+                .collect::<Vec<[u8; 16]>>();
+            let lut = (0..110)
+                .map(|_| std::array::from_fn(|_| rand::random()))
+                .collect::<Vec<[u8; 16]>>();
             for n in 90..110 {
-                let code = (0..n)
-                    .map(|_| std::array::from_fn(|_| rand::random()))
-                    .collect::<Vec<[u8; 16]>>();
-                let lut = (0..n)
-                    .map(|_| std::array::from_fn(|_| rand::random()))
-                    .collect::<Vec<[u8; 16]>>();
+                let code = &code[..n];
+                let lut = &lut[..n];
                 unsafe {
                     assert_eq!(scan_p9(&code, &lut), fallback(&code, &lut));
                 }
@@ -634,20 +646,22 @@ mod scan {
 
     #[cfg(all(target_arch = "powerpc64", test))]
     #[test]
-    #[cfg(miri, ignore)]
+    #[cfg_attr(miri, ignore)]
     fn scan_p8_test() {
         if !crate::is_cpu_detected!("p8") {
             println!("test {} ... skipped (p8)", module_path!());
             return;
         }
         for _ in 0..if cfg!(not(miri)) { 256 } else { 1 } {
+            let code = (0..110)
+                .map(|_| std::array::from_fn(|_| rand::random()))
+                .collect::<Vec<[u8; 16]>>();
+            let lut = (0..110)
+                .map(|_| std::array::from_fn(|_| rand::random()))
+                .collect::<Vec<[u8; 16]>>();
             for n in 90..110 {
-                let code = (0..n)
-                    .map(|_| std::array::from_fn(|_| rand::random()))
-                    .collect::<Vec<[u8; 16]>>();
-                let lut = (0..n)
-                    .map(|_| std::array::from_fn(|_| rand::random()))
-                    .collect::<Vec<[u8; 16]>>();
+                let code = &code[..n];
+                let lut = &lut[..n];
                 unsafe {
                     assert_eq!(scan_p8(&code, &lut), fallback(&code, &lut));
                 }
@@ -660,20 +674,22 @@ mod scan {
 
     #[cfg(all(target_arch = "powerpc64", test))]
     #[test]
-    #[cfg(miri, ignore)]
+    #[cfg_attr(miri, ignore)]
     fn scan_p7_test() {
         if !crate::is_cpu_detected!("p7") {
             println!("test {} ... skipped (p7)", module_path!());
             return;
         }
         for _ in 0..if cfg!(not(miri)) { 256 } else { 1 } {
+            let code = (0..110)
+                .map(|_| std::array::from_fn(|_| rand::random()))
+                .collect::<Vec<[u8; 16]>>();
+            let lut = (0..110)
+                .map(|_| std::array::from_fn(|_| rand::random()))
+                .collect::<Vec<[u8; 16]>>();
             for n in 90..110 {
-                let code = (0..n)
-                    .map(|_| std::array::from_fn(|_| rand::random()))
-                    .collect::<Vec<[u8; 16]>>();
-                let lut = (0..n)
-                    .map(|_| std::array::from_fn(|_| rand::random()))
-                    .collect::<Vec<[u8; 16]>>();
+                let code = &code[..n];
+                let lut = &lut[..n];
                 unsafe {
                     assert_eq!(scan_p7(&code, &lut), fallback(&code, &lut));
                 }

--- a/crates/simd/src/lib.rs
+++ b/crates/simd/src/lib.rs
@@ -65,12 +65,26 @@ impl F16 for f16 {
 
     #[inline(always)]
     fn _from_f32(x: f32) -> Self {
-        f16::from_f32(x)
+        #[cfg(not(miri))]
+        {
+            f16::from_f32(x)
+        }
+        #[cfg(miri)]
+        {
+            f16::from_f32_const(x)
+        }
     }
 
     #[inline(always)]
     fn _to_f32(self) -> f32 {
-        self.to_f32()
+        #[cfg(not(miri))]
+        {
+            self.to_f32()
+        }
+        #[cfg(miri)]
+        {
+            self.to_f32_const()
+        }
     }
 }
 

--- a/src/index/vchordg/am/am_build.rs
+++ b/src/index/vchordg/am/am_build.rs
@@ -594,18 +594,15 @@ unsafe fn options(
         d: opfamily.distance_kind(),
     };
     // get indexing, segment, optimizing
-    let rabitq = 'rabitq: {
+    let indexing_options = {
         let reloption = unsafe { (*index_relation).rd_options as *const Reloption };
-        if reloption.is_null() || unsafe { (*reloption).options == 0 } {
-            break 'rabitq Default::default();
-        }
-        let s = unsafe { Reloption::options(reloption) }.to_string_lossy();
+        let s = unsafe { Reloption::options(reloption, c"") }.to_string_lossy();
         match toml::from_str::<VchordgIndexingOptions>(&s) {
             Ok(p) => p,
             Err(e) => pgrx::error!("failed to parse options: {}", e),
         }
     };
-    (vector, rabitq)
+    (vector, indexing_options)
 }
 
 mod vchordg_cached {

--- a/src/index/vchordrq/am/am_build.rs
+++ b/src/index/vchordrq/am/am_build.rs
@@ -1246,18 +1246,15 @@ unsafe fn options(
         d: opfamily.distance_kind(),
     };
     // get indexing, segment, optimizing
-    let rabitq = 'rabitq: {
+    let indexing_options = {
         let reloption = unsafe { (*index_relation).rd_options as *const Reloption };
-        if reloption.is_null() || unsafe { (*reloption).options == 0 } {
-            break 'rabitq Default::default();
-        }
-        let s = unsafe { Reloption::options(reloption) }.to_string_lossy();
+        let s = unsafe { Reloption::options(reloption, c"") }.to_string_lossy();
         match toml::from_str::<VchordrqIndexingOptions>(&s) {
             Ok(p) => p,
             Err(e) => pgrx::error!("failed to parse options: {}", e),
         }
     };
-    (vector, rabitq)
+    (vector, indexing_options)
 }
 
 fn make_default_build(

--- a/src/index/vchordrq/types.rs
+++ b/src/index/vchordrq/types.rs
@@ -177,6 +177,7 @@ pub struct VchordrqIndexingOptions {
     #[serde(flatten)]
     #[validate(nested)]
     pub index: VchordrqIndexOptions,
+    #[serde(default)]
     #[validate(nested)]
     pub build: VchordrqBuildOptions,
 }

--- a/tests/vchordg/index_vector_rabitq.slt
+++ b/tests/vchordg/index_vector_rabitq.slt
@@ -78,7 +78,7 @@ statement ok
 CREATE INDEX ti ON t USING vchordg ((quantize_to_rabitq8(val::halfvec)::rabitq8(64)) rabitq8_l2_ops);
 
 query I
-SELECT index FROM t ORDER BY quantize_to_rabitq8(val::halfvec) <-> quantize_to_rabitq8(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::halfvec) LIMIT 10;
+SELECT index FROM t ORDER BY quantize_to_rabitq8(val::halfvec) <-> quantize_to_rabitq8(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::halfvec) LIMIT 9;
 ----
 155
 1608
@@ -89,7 +89,6 @@ SELECT index FROM t ORDER BY quantize_to_rabitq8(val::halfvec) <-> quantize_to_r
 1629
 60
 218
-1639
 
 statement ok
 DROP INDEX ti;
@@ -98,7 +97,7 @@ statement ok
 CREATE INDEX ti ON t USING vchordg ((quantize_to_rabitq8(val::halfvec)::rabitq8(64)) rabitq8_ip_ops);
 
 query I
-SELECT index FROM t ORDER BY quantize_to_rabitq8(val::halfvec) <#> quantize_to_rabitq8(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::halfvec) LIMIT 10;
+SELECT index FROM t ORDER BY quantize_to_rabitq8(val::halfvec) <#> quantize_to_rabitq8(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::halfvec) LIMIT 9;
 ----
 155
 1608
@@ -109,7 +108,6 @@ SELECT index FROM t ORDER BY quantize_to_rabitq8(val::halfvec) <#> quantize_to_r
 1629
 60
 218
-1639
 
 statement ok
 DROP INDEX ti;
@@ -118,7 +116,7 @@ statement ok
 CREATE INDEX ti ON t USING vchordg ((quantize_to_rabitq8(val::halfvec)::rabitq8(64)) rabitq8_cosine_ops);
 
 query I
-SELECT index FROM t ORDER BY quantize_to_rabitq8(val::halfvec) <=> quantize_to_rabitq8(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::halfvec) LIMIT 10;
+SELECT index FROM t ORDER BY quantize_to_rabitq8(val::halfvec) <=> quantize_to_rabitq8(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::halfvec) LIMIT 9;
 ----
 155
 1608
@@ -129,7 +127,6 @@ SELECT index FROM t ORDER BY quantize_to_rabitq8(val::halfvec) <=> quantize_to_r
 1629
 60
 218
-1639
 
 statement ok
 DROP INDEX ti;
@@ -138,11 +135,11 @@ statement ok
 CREATE INDEX ti ON t USING vchordg ((quantize_to_rabitq4(val)::rabitq4(64)) rabitq4_l2_ops);
 
 query I
-SELECT SUM(index) FROM (
+SELECT (SUM(index) = 6162 OR SUM(index) = 6289)::int FROM (
 SELECT index FROM t ORDER BY quantize_to_rabitq4(val) <-> quantize_to_rabitq4(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::vector) LIMIT 10
 ) AS s(index);
 ----
-6162
+1
 
 statement ok
 DROP INDEX ti;
@@ -151,11 +148,11 @@ statement ok
 CREATE INDEX ti ON t USING vchordg ((quantize_to_rabitq4(val)::rabitq4(64)) rabitq4_ip_ops);
 
 query I
-SELECT SUM(index) FROM (
+SELECT (SUM(index) = 6162 OR SUM(index) = 6289)::int FROM (
 SELECT index FROM t ORDER BY quantize_to_rabitq4(val) <#> quantize_to_rabitq4(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::vector) LIMIT 10
 ) AS s(index);
 ----
-6162
+1
 
 statement ok
 DROP INDEX ti;
@@ -164,11 +161,11 @@ statement ok
 CREATE INDEX ti ON t USING vchordg ((quantize_to_rabitq4(val)::rabitq4(64)) rabitq4_cosine_ops);
 
 query I
-SELECT SUM(index) FROM (
+SELECT (SUM(index) = 6162 OR SUM(index) = 6289)::int FROM (
 SELECT index FROM t ORDER BY quantize_to_rabitq4(val) <=> quantize_to_rabitq4(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::vector) LIMIT 10
 ) AS s(index);
 ----
-6162
+1
 
 statement ok
 DROP INDEX ti;

--- a/tests/vchordrq/index_vector_rabitq.slt
+++ b/tests/vchordrq/index_vector_rabitq.slt
@@ -78,7 +78,7 @@ statement ok
 CREATE INDEX ti ON t USING vchordrq ((quantize_to_rabitq8(val::halfvec)::rabitq8(64)) rabitq8_l2_ops);
 
 query I
-SELECT index FROM t ORDER BY quantize_to_rabitq8(val::halfvec) <-> quantize_to_rabitq8(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::halfvec) LIMIT 10;
+SELECT index FROM t ORDER BY quantize_to_rabitq8(val::halfvec) <-> quantize_to_rabitq8(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::halfvec) LIMIT 9;
 ----
 155
 1608
@@ -89,7 +89,6 @@ SELECT index FROM t ORDER BY quantize_to_rabitq8(val::halfvec) <-> quantize_to_r
 1629
 60
 218
-1639
 
 statement ok
 DROP INDEX ti;
@@ -98,7 +97,7 @@ statement ok
 CREATE INDEX ti ON t USING vchordrq ((quantize_to_rabitq8(val::halfvec)::rabitq8(64)) rabitq8_ip_ops);
 
 query I
-SELECT index FROM t ORDER BY quantize_to_rabitq8(val::halfvec) <#> quantize_to_rabitq8(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::halfvec) LIMIT 10;
+SELECT index FROM t ORDER BY quantize_to_rabitq8(val::halfvec) <#> quantize_to_rabitq8(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::halfvec) LIMIT 9;
 ----
 155
 1608
@@ -109,7 +108,6 @@ SELECT index FROM t ORDER BY quantize_to_rabitq8(val::halfvec) <#> quantize_to_r
 1629
 60
 218
-1639
 
 statement ok
 DROP INDEX ti;
@@ -118,7 +116,7 @@ statement ok
 CREATE INDEX ti ON t USING vchordrq ((quantize_to_rabitq8(val::halfvec)::rabitq8(64)) rabitq8_cosine_ops);
 
 query I
-SELECT index FROM t ORDER BY quantize_to_rabitq8(val::halfvec) <=> quantize_to_rabitq8(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::halfvec) LIMIT 10;
+SELECT index FROM t ORDER BY quantize_to_rabitq8(val::halfvec) <=> quantize_to_rabitq8(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::halfvec) LIMIT 9;
 ----
 155
 1608
@@ -129,7 +127,6 @@ SELECT index FROM t ORDER BY quantize_to_rabitq8(val::halfvec) <=> quantize_to_r
 1629
 60
 218
-1639
 
 statement ok
 DROP INDEX ti;
@@ -138,11 +135,11 @@ statement ok
 CREATE INDEX ti ON t USING vchordrq ((quantize_to_rabitq4(val)::rabitq4(64)) rabitq4_l2_ops);
 
 query I
-SELECT SUM(index) FROM (
+SELECT (SUM(index) = 6162 OR SUM(index) = 6289)::int FROM (
 SELECT index FROM t ORDER BY quantize_to_rabitq4(val) <-> quantize_to_rabitq4(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::vector) LIMIT 10
 ) AS s(index);
 ----
-6162
+1
 
 statement ok
 DROP INDEX ti;
@@ -151,11 +148,11 @@ statement ok
 CREATE INDEX ti ON t USING vchordrq ((quantize_to_rabitq4(val)::rabitq4(64)) rabitq4_ip_ops);
 
 query I
-SELECT SUM(index) FROM (
+SELECT (SUM(index) = 6162 OR SUM(index) = 6289)::int FROM (
 SELECT index FROM t ORDER BY quantize_to_rabitq4(val) <#> quantize_to_rabitq4(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::vector) LIMIT 10
 ) AS s(index);
 ----
-6162
+1
 
 statement ok
 DROP INDEX ti;
@@ -164,11 +161,11 @@ statement ok
 CREATE INDEX ti ON t USING vchordrq ((quantize_to_rabitq4(val)::rabitq4(64)) rabitq4_cosine_ops);
 
 query I
-SELECT SUM(index) FROM (
+SELECT (SUM(index) = 6162 OR SUM(index) = 6289)::int FROM (
 SELECT index FROM t ORDER BY quantize_to_rabitq4(val) <=> quantize_to_rabitq4(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::vector) LIMIT 10
 ) AS s(index);
 ----
-6162
+1
 
 statement ok
 DROP INDEX ti;
@@ -177,18 +174,11 @@ statement ok
 CREATE INDEX ti ON t USING vchordrq ((quantize_to_rabitq4(val::halfvec)::rabitq4(64)) rabitq4_l2_ops);
 
 query I
-SELECT index FROM t ORDER BY quantize_to_rabitq4(val::halfvec) <-> quantize_to_rabitq4(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::halfvec) LIMIT 10;
+SELECT SUM(index) FROM (
+SELECT index FROM t ORDER BY quantize_to_rabitq4(val::halfvec) <-> quantize_to_rabitq4(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::halfvec) LIMIT 10
+) AS s(index);
 ----
-818
-1608
-155
-60
-174
-1639
-1080
-218
-1207
-331
+7290
 
 statement ok
 DROP INDEX ti;
@@ -197,18 +187,11 @@ statement ok
 CREATE INDEX ti ON t USING vchordrq ((quantize_to_rabitq4(val::halfvec)::rabitq4(64)) rabitq4_ip_ops);
 
 query I
-SELECT index FROM t ORDER BY quantize_to_rabitq4(val::halfvec) <#> quantize_to_rabitq4(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::halfvec) LIMIT 10;
+SELECT SUM(index) FROM (
+SELECT index FROM t ORDER BY quantize_to_rabitq4(val::halfvec) <#> quantize_to_rabitq4(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::halfvec) LIMIT 10
+) AS s(index);
 ----
-818
-1608
-155
-60
-174
-1639
-1080
-218
-1207
-331
+7290
 
 statement ok
 DROP INDEX ti;
@@ -217,18 +200,11 @@ statement ok
 CREATE INDEX ti ON t USING vchordrq ((quantize_to_rabitq4(val::halfvec)::rabitq4(64)) rabitq4_cosine_ops);
 
 query I
-SELECT index FROM t ORDER BY quantize_to_rabitq4(val::halfvec) <=> quantize_to_rabitq4(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::halfvec) LIMIT 10;
+SELECT SUM(index) FROM (
+SELECT index FROM t ORDER BY quantize_to_rabitq4(val::halfvec) <=> quantize_to_rabitq4(array_cat(ARRAY[0.6, 0.8], ARRAY(SELECT 0.0 FROM generate_series(1, 62)))::halfvec) LIMIT 10
+) AS s(index);
 ----
-818
-1608
-155
-60
-174
-1639
-1080
-218
-1207
-331
+7290
 
 statement ok
 DROP INDEX ti;

--- a/tests/vchordrq/options.slt
+++ b/tests/vchordrq/options.slt
@@ -1,0 +1,46 @@
+statement ok
+SET enable_seqscan TO off;
+
+statement ok
+CREATE TABLE t (val vector(3));
+
+statement ok
+INSERT INTO t (val) VALUES ('[1,1,1]'), ('[2,2,2]');
+
+statement ok
+CREATE INDEX i ON t USING vchordrq (val vector_l2_ops)
+WITH (options = $$
+build.internal.lists = [2]
+$$, probes = '2');
+
+query T
+SELECT val FROM t ORDER BY val <-> '[0,0,0]' LIMIT 10;
+----
+[1,1,1]
+[2,2,2]
+
+statement ok
+SET vchordrq.probes TO '1';
+
+query T
+SELECT val FROM t ORDER BY val <-> '[0,0,0]' LIMIT 10;
+----
+[1,1,1]
+
+statement ok
+ALTER INDEX i SET (probes = '0');
+
+query T
+SELECT val FROM t ORDER BY val <-> '[0,0,0]' LIMIT 10;
+----
+[1,1,1]
+
+statement ok
+SET vchordrq.probes TO DEFAULT;
+
+query T
+SELECT val FROM t ORDER BY val <-> '[0,0,0]' LIMIT 10;
+----
+
+statement ok
+DROP TABLE t;


### PR DESCRIPTION
```sql
CREATE INDEX i ON t USING vchordrq (embedding vector_l2_ops) with (options = $$
build.internal.lists = [1024]
$$, probes = '32');

-- vchordrq.probes is not set; `vchordrq.probes = 32` according to the index option
SELECT id FROM t ORDER BY t <-> '[1,1,1]';

SET vchordrq.probes TO '64';
-- vchordrq.probes is set; `vchordrq.probes = 64` according to the GUC
SELECT id FROM t ORDER BY t <-> '[1,1,1]';

SET vchordrq.probes TO default;
-- vchordrq.probes is not set again; `vchordrq.probes = 32` according to the index option
SELECT id FROM t ORDER BY t <-> '[1,1,1]';

ALTER INDEX i SET (probes = '64');
-- vchordrq.probes is not set; `vchordrq.probes = 64` according to the index option
SELECT id FROM t ORDER BY t <-> '[1,1,1]';
```

#392