### PR TITLE
fix: skip recorder and sqlite state creation when vchord extension is not created

### DIFF
--- a/src/recorder/worker.rs
+++ b/src/recorder/worker.rs
@@ -32,6 +32,12 @@ fn get<'a>() -> Option<RefMut<'a, rusqlite::Connection>> {
     if database_oid == 0 {
         return None;
     }
+    // Skip if vchord extension is not installed in this database
+    if unsafe { pgrx::pg_sys::get_extension_oid(c"vchord".as_ptr(), true) }
+        == pgrx::pg_sys::InvalidOid
+    {
+        return None;
+    }
     let mut connection = CONNECTION.borrow_mut();
     if connection.is_none()
         && let Err(err) = || -> rusqlite::Result<()> {


### PR DESCRIPTION


When vchord is added to shared_preload_libraries without running CREATE EXTENSION, the object_access_hook fires on any DROP TABLE or DROP DATABASE and calls the recorder's get() function, which lazily creates the pgsql_tmp_vchord_sampling/ directory and SQLite files under PGDATA.

This is unnecessary and confusing when looking at contents of PGDATA and seeing files from an extension that has never been enabled

The commit skips all recorder operations when the extension has never been created (extension does not have an assigned OID)